### PR TITLE
feat: allowing a sensitivity parameter like rawaccel

### DIFF
--- a/driver/accel.h
+++ b/driver/accel.h
@@ -35,8 +35,10 @@ extern inline fixedpt acceleration_factor(fixedpt input_speed,
 
   accel_factor = fixedpt_mul(accel_factor, param_sensitivity);
 
-  if (param_output_cap != FIXEDPT_ZERO && accel_factor > param_output_cap) {
-    accel_factor = param_output_cap;
+  fixedpt output_cap = fixedpt_mul(param_output_cap, param_sensitivity);
+
+  if (param_output_cap != FIXEDPT_ZERO && accel_factor > output_cap) {
+    accel_factor = output_cap;
   }
 
   return accel_factor;

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -19,9 +19,6 @@ extern inline fixedpt sensitivity(fixedpt input_speed, fixedpt param_sens_mult,
                                   fixedpt param_accel, fixedpt param_offset,
                                   fixedpt param_output_cap) {
 
-  // printk("input speed %s, with interval %s", fixedpt_cstr(speed_in, 5),
-  //        fixedpt_cstr(polling_interval, 5));
-
   input_speed = fixedpt_sub(input_speed, param_offset);
 
   fixedpt sens = FIXEDPT_ONE;
@@ -54,23 +51,13 @@ static inline AccelResult f_accelerate(s8 x, s8 y, u32 polling_interval,
   fixedpt dx = fixedpt_fromint(x);
   fixedpt dy = fixedpt_fromint(y);
 
-  // printk(KERN_INFO "[MOUSE_MOVE] (%s, %s)", fixedpt_cstr(dx, 5),
-  //        fixedpt_cstr(dy, 5));
-
   fixedpt distance =
       fixedpt_sqrt(fixedpt_add(fixedpt_mul(dx, dx), fixedpt_mul(dy, dy)));
 
-  // printk("distance %s", fixedpt_cstr(distance, 5));
-
   fixedpt speed_in = fixedpt_div(distance, fixedpt_fromint(polling_interval));
-
-  // printk("input speed %s, with interval %s", fixedpt_cstr(speed_in, 5),
-  //        fixedpt_cstr(fixedpt_fromint(polling_interval), 5));
 
   fixedpt sens = sensitivity(speed_in, param_sens_mult, param_accel,
                              param_offset, param_output_cap);
-
-  // printk("accel_factor %s", fixedpt_cstr(accel_factor, 5));
 
   fixedpt dx_out = fixedpt_mul(dx, sens);
   fixedpt dy_out = fixedpt_mul(dy, sens);
@@ -83,11 +70,6 @@ static inline AccelResult f_accelerate(s8 x, s8 y, u32 polling_interval,
 
   carry_x = fixedpt_sub(dx_out, fixedpt_fromint(result.x));
   carry_y = fixedpt_sub(dy_out, fixedpt_fromint(result.y));
-
-  // printk(KERN_INFO "[MOUSE_MOVE_ACCEL] (%d, %d)", result.x, result.y);
-
-  // printk(KERN_INFO "[MOUSE_MOVE] carry (%s, %s)", fixedpt_cstr(carry_x, 5),
-  //        fixedpt_cstr(carry_y, 5));
 
   return result;
 }

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -31,12 +31,12 @@ extern inline fixedpt acceleration_factor(fixedpt input_speed,
   if (input_speed > FIXEDPT_ZERO) {
     accel_factor =
         fixedpt_add(FIXEDPT_ONE, fixedpt_mul((param_accel), input_speed));
+  }
 
-    accel_factor = fixedpt_mul(accel_factor, param_sensitivity);
+  accel_factor = fixedpt_mul(accel_factor, param_sensitivity);
 
-    if (param_output_cap != FIXEDPT_ZERO && accel_factor > param_output_cap) {
-      accel_factor = param_output_cap;
-    }
+  if (param_output_cap != FIXEDPT_ZERO && accel_factor > param_output_cap) {
+    accel_factor = param_output_cap;
   }
 
   return accel_factor;

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -16,6 +16,7 @@ static const fixedpt FIXEDPT_ZERO = fixedpt_rconst(0.0);
  *
  */
 extern inline fixedpt acceleration_factor(fixedpt input_speed,
+                                          fixedpt param_sensitivity,
                                           fixedpt param_accel,
                                           fixedpt param_offset,
                                           fixedpt param_output_cap) {
@@ -36,10 +37,13 @@ extern inline fixedpt acceleration_factor(fixedpt input_speed,
     }
   }
 
+  accel_factor = fixedpt_mul(accel_factor, param_sensitivity);
+
   return accel_factor;
 }
 
 static inline AccelResult f_accelerate(s8 x, s8 y, u32 polling_interval,
+                                       fixedpt param_sensitivity,
                                        fixedpt param_accel,
                                        fixedpt param_offset,
                                        fixedpt param_output_cap) {
@@ -64,8 +68,8 @@ static inline AccelResult f_accelerate(s8 x, s8 y, u32 polling_interval,
   // printk("input speed %s, with interval %s", fixedpt_cstr(speed_in, 5),
   //        fixedpt_cstr(fixedpt_fromint(polling_interval), 5));
 
-  fixedpt accel_factor = acceleration_factor(speed_in, param_accel,
-                                             param_offset, param_output_cap);
+  fixedpt accel_factor = acceleration_factor(
+      speed_in, param_sensitivity, param_accel, param_offset, param_output_cap);
 
   // printk("accel_factor %s", fixedpt_cstr(accel_factor, 5));
 

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -11,41 +11,38 @@ typedef struct {
 static const fixedpt FIXEDPT_ZERO = fixedpt_rconst(0.0);
 
 /**
- * Calculate the normalized factor by which to multiply the input vector
+ * Calculate the factor by which to multiply the input vector
  * in order to get the desired output speed.
  *
  */
-extern inline fixedpt acceleration_factor(fixedpt input_speed,
-                                          fixedpt param_sensitivity,
-                                          fixedpt param_accel,
-                                          fixedpt param_offset,
-                                          fixedpt param_output_cap) {
+extern inline fixedpt sensitivity(fixedpt input_speed, fixedpt param_sens_mult,
+                                  fixedpt param_accel, fixedpt param_offset,
+                                  fixedpt param_output_cap) {
 
   // printk("input speed %s, with interval %s", fixedpt_cstr(speed_in, 5),
   //        fixedpt_cstr(polling_interval, 5));
 
   input_speed = fixedpt_sub(input_speed, param_offset);
 
-  fixedpt accel_factor = FIXEDPT_ONE;
+  fixedpt sens = FIXEDPT_ONE;
 
   if (input_speed > FIXEDPT_ZERO) {
-    accel_factor =
-        fixedpt_add(FIXEDPT_ONE, fixedpt_mul((param_accel), input_speed));
+    sens = fixedpt_add(FIXEDPT_ONE, fixedpt_mul((param_accel), input_speed));
   }
 
-  accel_factor = fixedpt_mul(accel_factor, param_sensitivity);
+  sens = fixedpt_mul(sens, param_sens_mult);
 
-  fixedpt output_cap = fixedpt_mul(param_output_cap, param_sensitivity);
+  fixedpt output_cap = fixedpt_mul(param_output_cap, param_sens_mult);
 
-  if (param_output_cap != FIXEDPT_ZERO && accel_factor > output_cap) {
-    accel_factor = output_cap;
+  if (param_output_cap != FIXEDPT_ZERO && sens > output_cap) {
+    sens = output_cap;
   }
 
-  return accel_factor;
+  return sens;
 }
 
 static inline AccelResult f_accelerate(s8 x, s8 y, u32 polling_interval,
-                                       fixedpt param_sensitivity,
+                                       fixedpt param_sens_mult,
                                        fixedpt param_accel,
                                        fixedpt param_offset,
                                        fixedpt param_output_cap) {
@@ -70,13 +67,13 @@ static inline AccelResult f_accelerate(s8 x, s8 y, u32 polling_interval,
   // printk("input speed %s, with interval %s", fixedpt_cstr(speed_in, 5),
   //        fixedpt_cstr(fixedpt_fromint(polling_interval), 5));
 
-  fixedpt accel_factor = acceleration_factor(
-      speed_in, param_sensitivity, param_accel, param_offset, param_output_cap);
+  fixedpt sens = sensitivity(speed_in, param_sens_mult, param_accel,
+                             param_offset, param_output_cap);
 
   // printk("accel_factor %s", fixedpt_cstr(accel_factor, 5));
 
-  fixedpt dx_out = fixedpt_mul(dx, accel_factor);
-  fixedpt dy_out = fixedpt_mul(dy, accel_factor);
+  fixedpt dx_out = fixedpt_mul(dx, sens);
+  fixedpt dy_out = fixedpt_mul(dy, sens);
 
   dx_out = fixedpt_add(dx_out, carry_x);
   dy_out = fixedpt_add(dy_out, carry_y);

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -32,12 +32,12 @@ extern inline fixedpt acceleration_factor(fixedpt input_speed,
     accel_factor =
         fixedpt_add(FIXEDPT_ONE, fixedpt_mul((param_accel), input_speed));
 
+    accel_factor = fixedpt_mul(accel_factor, param_sensitivity);
+
     if (param_output_cap != FIXEDPT_ZERO && accel_factor > param_output_cap) {
       accel_factor = param_output_cap;
     }
   }
-
-  accel_factor = fixedpt_mul(accel_factor, param_sensitivity);
 
   return accel_factor;
 }

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -59,7 +59,8 @@ static AccelResult inline accelerate(s8 x, s8 y) {
     ms = 100;
   }
 
-  return f_accelerate(x, y, ms, PARAM_ACCEL, PARAM_OFFSET, PARAM_OUTPUT_CAP);
+  return f_accelerate(x, y, ms, PARAM_SENSITIVITY, PARAM_ACCEL, PARAM_OFFSET,
+                      PARAM_OUTPUT_CAP);
 }
 
 void on_complete(struct urb *u) {

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -59,7 +59,7 @@ static AccelResult inline accelerate(s8 x, s8 y) {
     ms = 100;
   }
 
-  return f_accelerate(x, y, ms, PARAM_SENSITIVITY, PARAM_ACCEL, PARAM_OFFSET,
+  return f_accelerate(x, y, ms, PARAM_SENS_MULT, PARAM_ACCEL, PARAM_OFFSET,
                       PARAM_OUTPUT_CAP);
 }
 

--- a/driver/params.h
+++ b/driver/params.h
@@ -13,4 +13,4 @@ PARAM(
     "Control the sensitivity, a factor applied after the acceleration after.");
 PARAM(ACCEL, 0.0, "Control the acceleration factor.");
 PARAM(OFFSET, 0.0, "Control the input speed past which to allow acceleration.");
-PARAM(OUTPUT_CAP, 0.0, "Control the maximum output speed.");
+PARAM(OUTPUT_CAP, 0.0, "Control the maximum acceleration factor.");

--- a/driver/params.h
+++ b/driver/params.h
@@ -8,6 +8,9 @@
   module_param_named(param, PARAM_##param, int, RW_USER_GROUP);                \
   MODULE_PARM_DESC(param, desc);
 
+PARAM(
+    SENSITIVITY, 1.0,
+    "Control the sensitivity, a factor applied after the acceleration after.");
 PARAM(ACCEL, 0.0, "Control the acceleration factor.");
 PARAM(OFFSET, 0.0, "Control the input speed past which to allow acceleration.");
 PARAM(OUTPUT_CAP, 0.0, "Control the maximum output speed.");

--- a/driver/params.h
+++ b/driver/params.h
@@ -8,9 +8,8 @@
   module_param_named(param, PARAM_##param, int, RW_USER_GROUP);                \
   MODULE_PARM_DESC(param, desc);
 
-PARAM(
-    SENSITIVITY, 1.0,
-    "Control the sensitivity, a factor applied after the acceleration after.");
-PARAM(ACCEL, 0.0, "Control the acceleration factor.");
+PARAM(SENS_MULT, 1.0,
+      "A factor applied the sensitivity calculation after ACCEL is applied.");
+PARAM(ACCEL, 0.0, "Control the sensitivity calculation.");
 PARAM(OFFSET, 0.0, "Control the input speed past which to allow acceleration.");
-PARAM(OUTPUT_CAP, 0.0, "Control the maximum acceleration factor.");
+PARAM(OUTPUT_CAP, 0.0, "Control the maximum sensitivity.");

--- a/maccel-cli/src/libmaccel.c
+++ b/maccel-cli/src/libmaccel.c
@@ -1,7 +1,7 @@
 #include "../../driver/accel.h"
 #include "../../driver/fixedptc.h"
 
-extern char *fixedpt_to_str(fixedpt num) { return fixedpt_cstr(num, 3); }
+extern char *fixedpt_to_str(fixedpt num) { return fixedpt_cstr(num, 5); }
 
 extern fixedpt fixedpt_from_float(float value) { return fixedpt_rconst(value); }
 

--- a/maccel-cli/src/libmaccel.rs
+++ b/maccel-cli/src/libmaccel.rs
@@ -69,7 +69,7 @@ pub mod fixedptc {
         fn fixedpt_to_float(value: i32) -> f32;
     }
 
-    pub fn fixedpt_as_str(num: &i32) -> anyhow::Result<&str> {
+    fn fixedpt_as_str(num: &i32) -> anyhow::Result<&str> {
         unsafe {
             let s = CStr::from_ptr(fixedpt_to_str(*num));
             let s = core::str::from_utf8(s.to_bytes())?;
@@ -91,6 +91,14 @@ pub mod fixedptc {
                 let i = fixedpt_from_float(value);
                 return Fixedpt(i);
             }
+        }
+    }
+
+    impl<'a> TryFrom<&'a Fixedpt> for &'a str {
+        type Error = anyhow::Error;
+
+        fn try_from(value: &'a Fixedpt) -> Result<Self, Self::Error> {
+            return fixedpt_as_str(&value.0);
         }
     }
 

--- a/maccel-cli/src/libmaccel.rs
+++ b/maccel-cli/src/libmaccel.rs
@@ -2,18 +2,20 @@ use crate::params::Param;
 
 use self::fixedptc::Fixedpt;
 
-extern "C" {
-    fn acceleration_factor(
-        speed_in: i32,
-        param_sensitivity: i32,
-        param_accel: i32,
-        param_offset: i32,
-        param_output_cap: i32,
-    ) -> i32;
+mod c_lib {
+    extern "C" {
+        pub fn sensitivity(
+            speed_in: i32,
+            param_sens_mult: i32,
+            param_accel: i32,
+            param_offset: i32,
+            param_output_cap: i32,
+        ) -> i32;
+    }
 }
 
 pub struct Params {
-    sensitivity: i32,
+    sens_mult: i32,
     accel: i32,
     offset: i32,
     output_cap: i32,
@@ -22,9 +24,9 @@ pub struct Params {
 impl Params {
     pub fn new() -> Self {
         Self {
-            sensitivity: Param::Sensitivity
+            sens_mult: Param::SensMult
                 .get()
-                .expect("failed to read Sensitivity parameter")
+                .expect("failed to read Sens_Mult parameter")
                 .0,
             accel: Param::Accel
                 .get()
@@ -43,12 +45,12 @@ impl Params {
 }
 
 /// Ratio of Output speed to Input speed
-pub fn accel_factor(s_in: f32, params: Params) -> f64 {
+pub fn sensitivity(s_in: f32, params: Params) -> f64 {
     let s_in = fixedptc::fixedpt(s_in);
     let a_factor = unsafe {
-        acceleration_factor(
+        c_lib::sensitivity(
             s_in.0,
-            params.sensitivity,
+            params.sens_mult,
             params.accel,
             params.offset,
             params.output_cap,

--- a/maccel-cli/src/libmaccel.rs
+++ b/maccel-cli/src/libmaccel.rs
@@ -2,18 +2,6 @@ use crate::params::Param;
 
 use self::fixedptc::Fixedpt;
 
-mod c_lib {
-    extern "C" {
-        pub fn sensitivity(
-            speed_in: i32,
-            param_sens_mult: i32,
-            param_accel: i32,
-            param_offset: i32,
-            param_output_cap: i32,
-        ) -> i32;
-    }
-}
-
 pub struct Params {
     sens_mult: i32,
     accel: i32,
@@ -62,18 +50,13 @@ pub fn sensitivity(s_in: f32, params: Params) -> f64 {
 }
 
 pub mod fixedptc {
-    use std::ffi::c_char;
     use std::ffi::CStr;
 
-    extern "C" {
-        fn fixedpt_to_str(num: i32) -> *const c_char;
-        fn fixedpt_from_float(value: f32) -> i32;
-        fn fixedpt_to_float(value: i32) -> f32;
-    }
+    use super::c_lib;
 
     fn fixedpt_as_str(num: &i32) -> anyhow::Result<&str> {
         unsafe {
-            let s = CStr::from_ptr(fixedpt_to_str(*num));
+            let s = CStr::from_ptr(c_lib::fixedpt_to_str(*num));
             let s = core::str::from_utf8(s.to_bytes())?;
             return Ok(s);
         }
@@ -83,14 +66,14 @@ pub mod fixedptc {
 
     impl From<Fixedpt> for f32 {
         fn from(value: Fixedpt) -> Self {
-            unsafe { fixedpt_to_float(value.0) }
+            unsafe { c_lib::fixedpt_to_float(value.0) }
         }
     }
 
     impl From<f32> for Fixedpt {
         fn from(value: f32) -> Self {
             unsafe {
-                let i = fixedpt_from_float(value);
+                let i = c_lib::fixedpt_from_float(value);
                 return Fixedpt(i);
             }
         }
@@ -106,8 +89,28 @@ pub mod fixedptc {
 
     pub fn fixedpt(num: f32) -> Fixedpt {
         unsafe {
-            let i = fixedpt_from_float(num);
+            let i = c_lib::fixedpt_from_float(num);
             return Fixedpt(i);
         }
+    }
+}
+
+mod c_lib {
+    use std::ffi::c_char;
+
+    extern "C" {
+        pub fn sensitivity(
+            speed_in: i32,
+            param_sens_mult: i32,
+            param_accel: i32,
+            param_offset: i32,
+            param_output_cap: i32,
+        ) -> i32;
+    }
+
+    extern "C" {
+        pub fn fixedpt_to_str(num: i32) -> *const c_char;
+        pub fn fixedpt_from_float(value: f32) -> i32;
+        pub fn fixedpt_to_float(value: i32) -> f32;
     }
 }

--- a/maccel-cli/src/libmaccel.rs
+++ b/maccel-cli/src/libmaccel.rs
@@ -5,6 +5,7 @@ use self::fixedptc::Fixedpt;
 extern "C" {
     fn acceleration_factor(
         speed_in: i32,
+        param_sensitivity: i32,
         param_accel: i32,
         param_offset: i32,
         param_output_cap: i32,
@@ -12,6 +13,7 @@ extern "C" {
 }
 
 pub struct Params {
+    sensitivity: i32,
     accel: i32,
     offset: i32,
     output_cap: i32,
@@ -20,6 +22,10 @@ pub struct Params {
 impl Params {
     pub fn new() -> Self {
         Self {
+            sensitivity: Param::Sensitivity
+                .get()
+                .expect("failed to read Sensitivity parameter")
+                .0,
             accel: Param::Accel
                 .get()
                 .expect("failed to read Accel parameter")
@@ -39,8 +45,15 @@ impl Params {
 /// Ratio of Output speed to Input speed
 pub fn sensitivity(s_in: f32, params: Params) -> f64 {
     let s_in = fixedptc::fixedpt(s_in);
-    let a_factor =
-        unsafe { acceleration_factor(s_in.0, params.accel, params.offset, params.output_cap) };
+    let a_factor = unsafe {
+        acceleration_factor(
+            s_in.0,
+            params.sensitivity,
+            params.accel,
+            params.offset,
+            params.output_cap,
+        )
+    };
     let a_factor: f32 = Fixedpt(a_factor).into();
 
     return a_factor as f64;

--- a/maccel-cli/src/libmaccel.rs
+++ b/maccel-cli/src/libmaccel.rs
@@ -43,7 +43,7 @@ impl Params {
 }
 
 /// Ratio of Output speed to Input speed
-pub fn sensitivity(s_in: f32, params: Params) -> f64 {
+pub fn accel_factor(s_in: f32, params: Params) -> f64 {
     let s_in = fixedptc::fixedpt(s_in);
     let a_factor = unsafe {
         acceleration_factor(

--- a/maccel-cli/src/main.rs
+++ b/maccel-cli/src/main.rs
@@ -54,7 +54,9 @@ fn main() -> anyhow::Result<()> {
             name.set(value)?;
         }
         ParamsCommand::Get { name } => {
-            println!("{}", name.get_as_str()?);
+            let value = name.get()?;
+            let string_value: &str = (&value).try_into()?;
+            println!("{}", string_value);
         }
         ParamsCommand::Bind { device_id } => {
             bind_device(&device_id)?;

--- a/maccel-cli/src/params.rs
+++ b/maccel-cli/src/params.rs
@@ -1,4 +1,4 @@
-use crate::libmaccel::fixedptc::{fixedpt, fixedpt_as_str, Fixedpt};
+use crate::libmaccel::fixedptc::{fixedpt, Fixedpt};
 use std::{
     fs::File,
     io::Read,
@@ -10,7 +10,7 @@ use clap::ValueEnum;
 
 const SYS_MODULE_PATH: &str = "/sys/module/maccel";
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq)]
 pub enum Param {
     Sensitivity,
     Accel,
@@ -67,13 +67,6 @@ impl Param {
             .context(format!("couldn't interpert the parameter's value {}", buf))?;
 
         return Ok(Fixedpt(value));
-    }
-
-    pub fn get_as_str(&self) -> anyhow::Result<String> {
-        let value = self.get()?;
-        let value = fixedpt_as_str(&value.0)?.to_string();
-
-        return Ok(value);
     }
 
     pub fn display_name(&self) -> String {

--- a/maccel-cli/src/params.rs
+++ b/maccel-cli/src/params.rs
@@ -12,6 +12,7 @@ const SYS_MODULE_PATH: &str = "/sys/module/maccel";
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum Param {
+    Sensitivity,
     Accel,
     Offset,
     OutputCap,
@@ -82,6 +83,7 @@ impl Param {
     /// The cannonical name of parameter, exactly what can be read from /sys/module/maccel/parameters
     fn name(&self) -> &'static str {
         let param_name = match self {
+            Param::Sensitivity => "SENSITIVITY",
             Param::Accel => "ACCEL",
             Param::Offset => "OFFSET",
             Param::OutputCap => "OUTPUT_CAP",

--- a/maccel-cli/src/params.rs
+++ b/maccel-cli/src/params.rs
@@ -12,7 +12,7 @@ const SYS_MODULE_PATH: &str = "/sys/module/maccel";
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq)]
 pub enum Param {
-    Sensitivity,
+    SensMult,
     Accel,
     Offset,
     OutputCap,
@@ -76,7 +76,7 @@ impl Param {
     /// The cannonical name of parameter, exactly what can be read from /sys/module/maccel/parameters
     fn name(&self) -> &'static str {
         let param_name = match self {
-            Param::Sensitivity => "SENSITIVITY",
+            Param::SensMult => "SENS_MULT",
             Param::Accel => "ACCEL",
             Param::Offset => "OFFSET",
             Param::OutputCap => "OUTPUT_CAP",

--- a/maccel-cli/src/tui.rs
+++ b/maccel-cli/src/tui.rs
@@ -78,7 +78,7 @@ impl ParameterInput {
 
 struct AppState {
     tab_tick: u8,
-    parameters: [ParameterInput; 3],
+    parameters: [ParameterInput; 4],
 }
 
 impl AppState {
@@ -86,6 +86,7 @@ impl AppState {
         Self {
             tab_tick: 0,
             parameters: [
+                Param::Sensitivity.into(),
                 Param::Accel.into(),
                 Param::Offset.into(),
                 Param::OutputCap.into(),

--- a/maccel-cli/src/tui.rs
+++ b/maccel-cli/src/tui.rs
@@ -320,7 +320,7 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
 
     // Done with parameter inputs, now on to the graph
 
-    let (bounds, labels) = bounds_and_labels([0.0, 160.0], 8);
+    let (bounds, labels) = bounds_and_labels([0.0, 80.0], 8);
     let x_axis = Axis::default()
         .title("Speed_in".magenta())
         .style(Style::default().white())

--- a/maccel-cli/src/tui.rs
+++ b/maccel-cli/src/tui.rs
@@ -29,7 +29,7 @@ enum InputMode {
 
 struct ParameterInput {
     param: Param,
-    value: String,
+    value: f64,
     input: Input,
     input_mode: InputMode,
     error: Option<String>,
@@ -37,14 +37,15 @@ struct ParameterInput {
 
 impl From<Param> for ParameterInput {
     fn from(param: Param) -> Self {
-        let value = param
-            .get_as_str()
-            .expect("failed to read and initialize a parameter's value");
+        let value: f32 = param
+            .get()
+            .expect("failed to read and initialize a parameter's value")
+            .into();
 
         Self {
             param,
-            value: value.clone(),
-            input: value.into(),
+            value: value as f64,
+            input: value.to_string().into(),
             input_mode: InputMode::Normal,
             error: None,
         }
@@ -58,10 +59,12 @@ impl ParameterInput {
             .value()
             .parse()
             .context("should be a number")
-            .and_then(|value| self.param.set(value))
-        {
-            Ok(_) => {
-                self.value = self.input.value().into();
+            .and_then(|value| {
+                self.param.set(value)?;
+                Ok(value)
+            }) {
+            Ok(value) => {
+                self.value = value as f64;
                 self.error = None;
             }
             Err(err) => {
@@ -72,7 +75,7 @@ impl ParameterInput {
     }
 
     fn reset(&mut self) {
-        self.input = self.value.clone().into();
+        self.input = self.value.to_string().into();
     }
 }
 
@@ -324,7 +327,16 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
         .bounds(bounds)
         .labels(labels);
 
-    let (bounds, labels) = bounds_and_labels([0.0, 3.0], 3);
+    // To make the y axis bounds and labels scale with our sensitivity multiplier
+    let mut y_bounds = [0.0, 5.0];
+    y_bounds[1] *= app
+        .parameters
+        .iter()
+        .find(|&p| p.param == Param::Sensitivity)
+        .expect("we should include the Sensitivity param in the list")
+        .value;
+
+    let (bounds, labels) = bounds_and_labels(y_bounds, 5);
     let y_axis = Axis::default()
         .title("Acceleration Factor".magenta())
         .style(Style::default().white())

--- a/maccel-cli/src/tui.rs
+++ b/maccel-cli/src/tui.rs
@@ -375,11 +375,10 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
 fn bounds_and_labels(bounds: [f64; 2], div: usize) -> ([f64; 2], Vec<Span<'static>>) {
     let [o, f] = bounds;
     let d = f - o;
-    // let gap = 1f64;
-    let gap = d / (div as f64);
+    let step = d / (div as f64);
 
     let labels = (0..=div)
-        .map(|i| o + i as f64 * gap)
+        .map(|i| o + i as f64 * step)
         .map(|label| format!("{:.2}", label).into())
         .collect();
 

--- a/maccel-cli/src/tui.rs
+++ b/maccel-cli/src/tui.rs
@@ -317,7 +317,7 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
 
     // Done with parameter inputs, now on to the graph
 
-    let (bounds, labels) = bounds_and_labels([0.0, 80.0], 8);
+    let (bounds, labels) = bounds_and_labels([0.0, 160.0], 8);
     let x_axis = Axis::default()
         .title("Speed_in".magenta())
         .style(Style::default().white())
@@ -337,7 +337,11 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
         .collect();
 
     let chart = Chart::new(vec![Dataset::default()
-        .name(format!("f(x) = 1 + {}⋅x", Param::Accel.display_name()))
+        .name(format!(
+            "f(x) = (1 + {}⋅x) ⋅ {}",
+            Param::Accel.display_name(),
+            Param::Sensitivity.display_name()
+        ))
         .marker(symbols::Marker::Braille)
         .graph_type(GraphType::Line)
         .style(Style::default().green())

--- a/maccel-cli/src/tui.rs
+++ b/maccel-cli/src/tui.rs
@@ -17,7 +17,7 @@ use std::io::stdout;
 use tui_input::{backend::crossterm::EventHandler, Input};
 
 use crate::{
-    libmaccel::{sensitivity, Params},
+    libmaccel::{accel_factor, Params},
     params::Param,
 };
 
@@ -326,14 +326,14 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
 
     let (bounds, labels) = bounds_and_labels([0.0, 3.0], 3);
     let y_axis = Axis::default()
-        .title("Sensitivity".magenta())
+        .title("Acceleration Factor".magenta())
         .style(Style::default().white())
         .bounds(bounds)
         .labels(labels);
 
     let data: Vec<_> = (0..100)
         .map(|x| x as f32)
-        .map(|x| (x as f64, sensitivity(x, Params::new())))
+        .map(|x| (x as f64, accel_factor(x, Params::new())))
         .collect();
 
     let chart = Chart::new(vec![Dataset::default()
@@ -353,7 +353,7 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
         chart.block(
             Block::default()
                 .borders(Borders::NONE)
-                .title("graph (Sensitivity = Speed_out / Speed_in)")
+                .title("graph (Acceleration Factor = Speed_out / Speed_in)")
                 .bold(),
         ),
         main_layout[1],

--- a/maccel-cli/src/tui.rs
+++ b/maccel-cli/src/tui.rs
@@ -17,7 +17,7 @@ use std::io::stdout;
 use tui_input::{backend::crossterm::EventHandler, Input};
 
 use crate::{
-    libmaccel::{accel_factor, Params},
+    libmaccel::{sensitivity, Params},
     params::Param,
 };
 
@@ -89,7 +89,7 @@ impl AppState {
         Self {
             tab_tick: 0,
             parameters: [
-                Param::Sensitivity.into(),
+                Param::SensMult.into(),
                 Param::Accel.into(),
                 Param::Offset.into(),
                 Param::OutputCap.into(),
@@ -332,27 +332,27 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
     y_bounds[1] *= app
         .parameters
         .iter()
-        .find(|&p| p.param == Param::Sensitivity)
-        .expect("we should include the Sensitivity param in the list")
+        .find(|&p| p.param == Param::SensMult)
+        .expect("we should include the Sensitivity multiplier param in the list")
         .value;
 
     let (bounds, labels) = bounds_and_labels(y_bounds, 5);
     let y_axis = Axis::default()
-        .title("Acceleration Factor".magenta())
+        .title("Sensitivity".magenta())
         .style(Style::default().white())
         .bounds(bounds)
         .labels(labels);
 
     let data: Vec<_> = (0..100)
         .map(|x| x as f32)
-        .map(|x| (x as f64, accel_factor(x, Params::new())))
+        .map(|x| (x as f64, sensitivity(x, Params::new())))
         .collect();
 
     let chart = Chart::new(vec![Dataset::default()
         .name(format!(
             "f(x) = (1 + {}⋅x) ⋅ {}",
             Param::Accel.display_name(),
-            Param::Sensitivity.display_name()
+            Param::SensMult.display_name()
         ))
         .marker(symbols::Marker::Braille)
         .graph_type(GraphType::Line)
@@ -365,7 +365,7 @@ fn ui(frame: &mut Frame, app: &mut AppState) {
         chart.block(
             Block::default()
                 .borders(Borders::NONE)
-                .title("graph (Acceleration Factor = Speed_out / Speed_in)")
+                .title("graph (Sensitivity = Speed_out / Speed_in)")
                 .bold(),
         ),
         main_layout[1],


### PR DESCRIPTION
I've been using my mouse DPI to manage my sensitivity, so I can keep it consistent at all times. But that seems like an antipattern now.

So I'll set my mouse dpi to `1600` and lower the sensitivity with this param.