### PR TITLE
chore: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Linear mouse acceleration.
 ![image](https://github.com/Gnarus-G/maccel/assets/37311893/f45bc4bc-f7a0-43b0-9e8c-b3f6fb958d4c)
 
-## Acceleration Funcion
+## Acceleration Function
 
 $$V = \frac{\sqrt{dx_0^2 + dy_0^2}}{i}$$
 
@@ -40,7 +40,7 @@ curl -fsSL https://www.maccel.org/uninstall.sh | sudo sh
 ## CLI Usage
 
 ```
-CLI to control the paramters for the maccel driver, and manage mice bindings
+CLI to control the parameters for the maccel driver, and manage mice bindings
 
 Usage: maccel <COMMAND>
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,7 +13,7 @@ use tui::run_tui;
 
 #[derive(Parser)]
 #[clap(author, about, version)]
-/// CLI to control the paramters for the maccel driver, and manage mice bindings
+/// CLI to control the parameters for the maccel driver, and manage mice bindings
 struct Cli {
     #[clap(subcommand)]
     command: Option<ParamsCommand>,

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -64,7 +64,7 @@ impl Param {
         let value: i32 = buf
             .trim()
             .parse()
-            .context(format!("couldn't interpert the parameter's value {}", buf))?;
+            .context(format!("couldn't interpret the parameter's value {}", buf))?;
 
         return Ok(Fixedpt(value));
     }
@@ -73,7 +73,7 @@ impl Param {
         return format!("{:?}", self);
     }
 
-    /// The cannonical name of parameter, exactly what can be read from /sys/module/maccel/parameters
+    /// The canonical name of parameter, exactly what can be read from /sys/module/maccel/parameters
     fn name(&self) -> &'static str {
         let param_name = match self {
             Param::SensMult => "SENS_MULT",

--- a/driver/fixedptc.h
+++ b/driver/fixedptc.h
@@ -144,7 +144,7 @@ static inline fixedpt fixedpt_div(fixedpt A, fixedpt B) {
 }
 
 /*
- * Note: adding and substracting fixedpt numbers can be done by using
+ * Note: adding and subtracting fixedpt numbers can be done by using
  * the regular integer operators + and -.
  */
 


### PR DESCRIPTION
fixes some typos found with [`typos-cli`](https://crates.io/crates/typos-cli)

thanks for the nice tool!
