### PR TITLE
Minor makefile/compiler fixups targeting Clang/LLVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-CC=gcc
+ifneq ($(CC),clang)
+	CC=gcc
+else
+	export LLVM=1
+endif
 DRIVERDIR?=`pwd`/driver
 KDIR?=/lib/modules/`uname -r`/build
 
@@ -16,7 +20,7 @@ debug_install: debug install
 
 install: default
 	@sudo insmod $(DRIVERDIR)/maccel.ko;
-	
+
 	@mkdir -p $(MODULEDIR)
 	@sudo cp -v $(DRIVERDIR)/*.ko $(MODULEDIR);
 	@sudo chown -v root:root $(MODULEDIR)/*.ko;
@@ -47,7 +51,7 @@ install_cli: build_cli
 uninstall_cli:
 	@sudo rm -f /usr/local/bin/maccel
 	@sudo rm -f /usr/local/bin/maccel-driver-binder
-	
+
 udev_install: install_cli
 	sudo install -m 644 -v -D `pwd`/udev_rules/99-maccel.rules /usr/lib/udev/rules.d/99-maccel.rules
 	sudo install -m 755 -v -D `pwd`/udev_rules/maccel_param_ownership_and_resets /usr/lib/udev/maccel_param_ownership_and_resets 

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -11,7 +11,7 @@ typedef struct {
   int y;
 } AccelResult;
 
-static const fixedpt FIXEDPT_ZERO = fixedpt_rconst(0.0);
+const fixedpt FIXEDPT_ZERO = fixedpt_rconst(0.0);
 
 /**
  * Calculate the factor by which to multiply the input vector

--- a/driver/usbmouse.h
+++ b/driver/usbmouse.h
@@ -49,7 +49,7 @@ static void on_complete(struct urb *u) {
     return;
   case -EOVERFLOW:
     printk(KERN_ALERT "EOVERFLOW");
-  default:
+  fallthrough; default:
     printk(KERN_ALERT "unknown status; will resubmit request block");
     goto resubmit;
   }


### PR DESCRIPTION
Some fixes to allow for Clang/LLVM and remove warnings for Clang.

1. Check CC variable from the shell for clang to set CC(from shell) and LLVM variables, may separate to allow other CCs, and remove tabs.
2. Remove static from FIXEDPT_ZERO for inline functions (it's a const anyway, so static doesn't seem to make sense).
3. Mark default with fallthrough attribute to silence warning, seems to be compatible with GCC and silence its warning.

Log without fixes.
```cc
chief@Master /tmp/git/maccel 
>  LLVM=1 make 
make CC=clang EXTRA_CFLAGS= -C /lib/modules/`uname -r`/build M=`pwd`/driver
make[1]: Entering directory '/usr/src/linux-git'
  CC [M]  /tmp/git/maccel/driver/maccel.o
In file included from /tmp/git/maccel/driver/maccel.c:1:
In file included from /tmp/git/maccel/driver/./input_handler.h:1:
In file included from /tmp/git/maccel/driver/././accelk.h:4:
/tmp/git/maccel/driver/././accel.h:31:21: warning: static variable 'FIXEDPT_ZERO' is used in an inline function with external linkage [-Wstatic-in-inline]
   31 |   if (input_speed > FIXEDPT_ZERO) {
      |                     ^
/tmp/git/maccel/driver/././accel.h:14:22: note: 'FIXEDPT_ZERO' declared here
   14 | static const fixedpt FIXEDPT_ZERO = fixedpt_rconst(0.0);
      |                      ^
/tmp/git/maccel/driver/././accel.h:42:27: warning: static variable 'FIXEDPT_ZERO' is used in an inline function with external linkage [-Wstatic-in-inline]
   42 |   if (param_output_cap != FIXEDPT_ZERO && sens > output_cap) {
      |                           ^
/tmp/git/maccel/driver/././accel.h:14:22: note: 'FIXEDPT_ZERO' declared here
   14 | static const fixedpt FIXEDPT_ZERO = fixedpt_rconst(0.0);
      |                      ^
In file included from /tmp/git/maccel/driver/maccel.c:2:
/tmp/git/maccel/driver/./usbmouse.h:52:3: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]
   52 |   default:
      |   ^
/tmp/git/maccel/driver/./usbmouse.h:52:3: note: insert '__attribute__((fallthrough));' to silence this warning
   52 |   default:
      |   ^
      |   __attribute__((fallthrough)); 
/tmp/git/maccel/driver/./usbmouse.h:52:3: note: insert 'break;' to avoid fall-through
   52 |   default:
      |   ^
      |   break; 
3 warnings generated.
  MODPOST /tmp/git/maccel/driver/Module.symvers
  CC [M]  /tmp/git/maccel/driver/maccel.mod.o
  LD [M]  /tmp/git/maccel/driver/maccel.ko
make[1]: Leaving directory '/usr/src/linux-git'
```
Log with fixes.
```cc
chief@Master /tmp/git/maccel 
>  CC=clang make            
make CC=clang EXTRA_CFLAGS= -C /lib/modules/`uname -r`/build M=`pwd`/driver
make[1]: Entering directory '/usr/src/linux-git'
  CC [M]  /tmp/git/maccel/driver/maccel.o
  MODPOST /tmp/git/maccel/driver/Module.symvers
  CC [M]  /tmp/git/maccel/driver/maccel.mod.o
  LD [M]  /tmp/git/maccel/driver/maccel.ko
make[1]: Leaving directory '/usr/src/linux-git'
```