### PR TITLE
Fix warnings when building with GCC

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -9,5 +9,6 @@ fn main() {
 
     println!("cargo:rerun-if-changed=src/libmaccel.c");
     println!("cargo:rerun-if-changed=../driver/accel.h");
+    println!("cargo:rerun-if-changed=../driver/accel_rs.h");
     println!("cargo:rerun-if-changed=../driver/fixedptc.h");
 }

--- a/cli/src/libmaccel.c
+++ b/cli/src/libmaccel.c
@@ -1,4 +1,4 @@
-#include "../../driver/accel.h"
+#include "../../driver/accel_rs.h"
 #include "../../driver/fixedptc.h"
 
 extern char *fixedpt_to_str(fixedpt num) { return fixedpt_cstr(num, 5); }

--- a/cli/src/libmaccel.rs
+++ b/cli/src/libmaccel.rs
@@ -36,7 +36,7 @@ impl Params {
 pub fn sensitivity(s_in: f32, params: Params) -> f64 {
     let s_in: Fixedpt = s_in.into();
     let a_factor = unsafe {
-        c_lib::sensitivity(
+        c_lib::sensitivity_rs(
             s_in.0,
             params.sens_mult,
             params.accel,
@@ -93,7 +93,7 @@ mod c_lib {
     use std::ffi::c_char;
 
     extern "C" {
-        pub fn sensitivity(
+        pub fn sensitivity_rs(
             speed_in: i32,
             param_sens_mult: i32,
             param_accel: i32,

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -18,7 +18,7 @@ const fixedpt FIXEDPT_ZERO = fixedpt_rconst(0.0);
  * in order to get the desired output speed.
  *
  */
-extern inline fixedpt sensitivity(fixedpt input_speed, fixedpt param_sens_mult,
+static inline fixedpt sensitivity(fixedpt input_speed, fixedpt param_sens_mult,
                                   fixedpt param_accel, fixedpt param_offset,
                                   fixedpt param_output_cap) {
 

--- a/driver/accel_rs.h
+++ b/driver/accel_rs.h
@@ -1,0 +1,7 @@
+#include "accel.h"
+
+extern inline fixedpt sensitivity_rs(fixedpt input_speed, fixedpt param_sens_mult,
+                                     fixedpt param_accel, fixedpt param_offset,
+                                     fixedpt param_output_cap) {
+  return sensitivity(input_speed, param_sens_mult, param_accel, param_offset, param_output_cap);
+}

--- a/driver/accelk.h
+++ b/driver/accelk.h
@@ -5,7 +5,7 @@
 #include "linux/ktime.h"
 #include "params.h"
 
-static AccelResult inline accelerate(int x, int y) {
+static inline AccelResult accelerate(int x, int y) {
   static ktime_t last;
   static u64 last_ms = 1;
 

--- a/driver/dbg.h
+++ b/driver/dbg.h
@@ -23,7 +23,7 @@
   }                                                                            \
   while (0)                                                                    \
   _Pragma("clang diagnostic pop")
-#else
+#elif defined __KERNEL__
 #define dbg_k(fmt, ...)                                                        \
   do {                                                                         \
     if (DEBUG_TEST)                                                            \
@@ -31,10 +31,7 @@
              __VA_ARGS__);                                                     \
   }                                                                            \
   while (0)
-#endif
-#endif
-
-#ifndef __KERNEL__
+#else
 #define dbg_std(fmt, ...)                                                      \
   do {                                                                         \
     if (DEBUG_TEST)                                                            \

--- a/driver/dbg.h
+++ b/driver/dbg.h
@@ -12,8 +12,7 @@
 #define dbg(fmt, ...) dbg_std(fmt, __VA_ARGS__)
 #endif
 
-#ifdef __KERNEL__
-#ifdef __clang__
+#if defined __KERNEL__ && defined __clang__
 #define dbg_k(fmt, ...)                                                        \
   _Pragma("clang diagnostic push")                                             \
       _Pragma("clang diagnostic ignored \"-Wstatic-local-in-inline\"") do {    \

--- a/driver/dbg.h
+++ b/driver/dbg.h
@@ -13,6 +13,7 @@
 #endif
 
 #ifdef __KERNEL__
+#ifdef __clang__
 #define dbg_k(fmt, ...)                                                        \
   _Pragma("clang diagnostic push")                                             \
       _Pragma("clang diagnostic ignored \"-Wstatic-local-in-inline\"") do {    \
@@ -22,6 +23,15 @@
   }                                                                            \
   while (0)                                                                    \
   _Pragma("clang diagnostic pop")
+#else
+#define dbg_k(fmt, ...)                                                        \
+  do {                                                                         \
+    if (DEBUG_TEST)                                                            \
+      printk(KERN_INFO "%s:%d:%s(): " #fmt "\n", __FILE__, __LINE__, __func__, \
+             __VA_ARGS__);                                                     \
+  }                                                                            \
+  while (0)
+#endif
 #endif
 
 #ifndef __KERNEL__


### PR DESCRIPTION
Fixing the warnings is necessary for a successful build when the kernel is built with the CONFIG_WERROR option. This option is default in at least the upstream kernel config.

This PR is marked as a draft because:

1. It needs testing with clang.
2. I'm not sure how the nested `#ifdef` in `driver/dbg.h` should be formatted.
3. Removing the `static` keyword from the fixedpt functions creates warnings in the rust CLI build. While it technically still works, I'm not sure how to fix these. Maybe a different approach should be taken.
Changing `extern` to `static` in the sensitivity function is an alternative fix, but it causes the CLI build to fail until changed back. Building the module with `static`, reverting it to `extern`, and then building the CLI works, if that's useful information.