### PR TITLE
Small cargo fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,5 @@ udev_trigger:
 
 clean:
 	rm -rf $(DRIVERDIR)/.*.cmd $(DRIVERDIR)/*.ko $(DRIVERDIR)/*.mod $(DRIVERDIR)/*.mod.* $(DRIVERDIR)/*.symvers $(DRIVERDIR)/*.order $(DRIVERDIR)/*.o
+	cargo clean --manifest-path=cli/Cargo.toml
+	cargo clean --manifest-path=cli/usbmouse/Cargo.toml

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -100,9 +100,12 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -388,6 +391,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,4 +19,4 @@ ratatui = "0.25.0"
 tui-input = "*"
 
 [build-dependencies]
-cc = "1.0.83"
+cc = "1.2.3"


### PR DESCRIPTION
Makes `make clean` more useful.
Fixes warning when building the rust CLI.