### PR TITLE
Remove virtual input device from input handler

### DIFF
--- a/bench/evinputlag.c
+++ b/bench/evinputlag.c
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#define VIRTUAL_DEVICE "/dev/input/event7"
+#define MOUSE_DEVICE "/dev/input/event7"
 
 static __suseconds_t to_us(struct timeval time) {
   return time.tv_sec * 1000000L + time.tv_usec;
@@ -23,9 +23,9 @@ static __suseconds_t to_us(struct timeval time) {
  */
 
 int main(void) {
-  int fd_source = open(VIRTUAL_DEVICE, O_RDONLY);
+  int fd_source = open(MOUSE_DEVICE, O_RDONLY);
   if (fd_source < 0) {
-    perror("Failed to open virtual device");
+    perror("Failed to open device");
     return 1;
   }
 

--- a/driver/input_echo.h
+++ b/driver/input_echo.h
@@ -8,7 +8,7 @@
  * Cache of the last [REL_X, REL_Y] values to report to userspace
  * on read.
  */
-static int input_cache[2] = {0};
+static int MOUSE_MOVE_CACHE[2] = {0};
 
 static struct cdev device;
 static struct class *device_class;
@@ -26,8 +26,8 @@ static void int_to_bytes(int num, char bytes[4]) {
 
 static ssize_t read(struct file *f, char __user *user_buffer, size_t size,
                     loff_t *offset) {
-  int x = input_cache[0];
-  int y = input_cache[1];
+  int x = MOUSE_MOVE_CACHE[0];
+  int y = MOUSE_MOVE_CACHE[1];
   fixedpt speed = input_speed(fixedpt_fromint(x), fixedpt_fromint(y), 1);
 
   signed char be_bytes_for_int[4] = {0};

--- a/driver/input_handler.h
+++ b/driver/input_handler.h
@@ -1,72 +1,78 @@
 #include "./accelk.h"
 #include "input_echo.h"
+#include "linux/input.h"
+#include "mouse_move.h"
 #include <linux/hid.h>
+#include <linux/version.h>
 
-static struct input_dev *virtual_input_dev;
+static struct input_dev *VIRTUAL_INPUT_DEV;
 
-#define NONE_EVENT_VALUE 0
-static int relative_axis_events[REL_CNT] = { // [x, y, ..., wheel, ...]
-    NONE_EVENT_VALUE};
-
-static bool maccel_filter(struct input_handle *handle, u32 type,
-
-                          u32 code, int value) {
+/*
+ * Collect the events EV_REL REL_X and EV_REL REL_Y, once we have both then
+ * we accelerate the (x, y) vector and set the EV_REL event's value
+ * through the `value_ptr` of each collected event.
+ */
+static void event(struct input_handle *handle, struct input_value *value_ptr) {
   /* printk(KERN_INFO "type %d, code %d, value %d", type, code, value); */
 
-  switch (type) {
+  switch (value_ptr->type) {
   case EV_REL: {
-    dbg("EV_REL => code %d, value %d", code, value);
-    relative_axis_events[code] = value;
+    dbg("EV_REL => code %d, value %d", value_ptr->code, value_ptr->value);
+    update_mouse_move(value_ptr);
 
     // So we can relay the original speed of the mouse movement to userspace
     // for visualization.
-    input_cache[0] = relative_axis_events[REL_X];
-    input_cache[1] = relative_axis_events[REL_Y];
+    MOUSE_MOVE_CACHE[0] = get_x(MOVEMENT);
+    MOUSE_MOVE_CACHE[1] = get_y(MOVEMENT);
 
-    return true; // so input system skips (filters out) this unaccelerated
-                 // mouse input.
+    return;
   }
   case EV_SYN: {
-    int x = relative_axis_events[REL_X];
-    int y = relative_axis_events[REL_Y];
+    int x = get_x(MOVEMENT);
+    int y = get_y(MOVEMENT);
     if (x || y) {
-      dbg("EV_SYN => code %d", code);
+      dbg("EV_SYN => code %d", value_ptr->code);
 
       AccelResult accelerated = accelerate(x, y);
       dbg("accel: (%d, %d) -> (%d, %d)", x, y, accelerated.x, accelerated.y);
-      x = accelerated.x;
-      y = accelerated.y;
+      set_x_move(accelerated.x);
+      set_y_move(accelerated.y);
 
-      if (x) {
-        input_report_rel(virtual_input_dev, REL_X, x);
-      }
-      if (y) {
-        input_report_rel(virtual_input_dev, REL_Y, y);
-      }
-
-      relative_axis_events[REL_X] = NONE_EVENT_VALUE;
-      relative_axis_events[REL_Y] = NONE_EVENT_VALUE;
+      clear_mouse_move();
     }
 
-    for (u32 code = REL_Z; code < REL_CNT; code++) {
-      int value = relative_axis_events[code];
-      if (value != NONE_EVENT_VALUE) {
-        input_report_rel(virtual_input_dev, code, value);
-        relative_axis_events[code] = NONE_EVENT_VALUE;
-      }
-    }
-
-    input_sync(virtual_input_dev);
-    return false;
+    return;
   }
-
   default:
-    return false;
+    return;
   }
 }
 
+static unsigned int maccel_events(struct input_handle *handle,
+                                  struct input_value *vals,
+                                  unsigned int count) {
+  struct input_value *v;
+  for (v = vals; v != vals + count; v++) {
+    event(handle, v);
+  }
+
+  struct input_value *end = vals;
+  for (v = vals; v != vals + count; v++) {
+    if (v->type == EV_REL && v->value == NONE_EVENT_VALUE)
+      continue;
+    if (end != v) {
+      *end = *v;
+    }
+    end++;
+  }
+
+  int _count = end - vals;
+  handle->dev->num_vals = _count;
+  return _count;
+}
+
 static bool maccel_match(struct input_handler *handler, struct input_dev *dev) {
-  if (dev == virtual_input_dev)
+  if (dev == VIRTUAL_INPUT_DEV)
     return false;
   if (!dev->dev.parent)
     return false;
@@ -78,6 +84,32 @@ static bool maccel_match(struct input_handler *handler, struct input_dev *dev) {
   /*        hdev->type == HID_TYPE_USBMOUSE ? "true" : "false"); */
 
   return hdev->type == HID_TYPE_USBMOUSE;
+}
+
+/* Same as Linux's input_register_handle but we always add the handle to the
+ * head of handlers */
+static int input_register_handle_head(struct input_handle *handle) {
+  struct input_handler *handler = handle->handler;
+  struct input_dev *dev = handle->dev;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 7))
+  /* In 6.11.7 an additional handler pointer was added:
+   * https://github.com/torvalds/linux/commit/071b24b54d2d05fbf39ddbb27dee08abd1d713f3
+   */
+  if (handler->events)
+    handle->handle_events = handler->events;
+#endif
+
+  int error = mutex_lock_interruptible(&dev->mutex);
+  if (error)
+    return error;
+
+  list_add_rcu(&handle->d_node, &dev->h_list);
+  mutex_unlock(&dev->mutex);
+  list_add_tail_rcu(&handle->h_node, &handler->h_list);
+  if (handler->start)
+    handler->start(handle);
+  return 0;
 }
 
 static int maccel_connect(struct input_handler *handler, struct input_dev *dev,
@@ -93,7 +125,7 @@ static int maccel_connect(struct input_handler *handler, struct input_dev *dev,
   handle->handler = handler;
   handle->name = "maccel";
 
-  error = input_register_handle(handle);
+  error = input_register_handle_head(handle);
   if (error)
     goto err_free_mem;
 
@@ -128,7 +160,7 @@ static const struct input_device_id my_ids[] = {
 
 MODULE_DEVICE_TABLE(input, my_ids);
 
-struct input_handler maccel_handler = {.filter = maccel_filter,
+struct input_handler maccel_handler = {.events = maccel_events,
                                        .connect = maccel_connect,
                                        .disconnect = maccel_disconnect,
                                        .name = "maccel",

--- a/driver/input_handler.h
+++ b/driver/input_handler.h
@@ -5,8 +5,6 @@
 #include <linux/hid.h>
 #include <linux/version.h>
 
-static struct input_dev *VIRTUAL_INPUT_DEV;
-
 /*
  * Collect the events EV_REL REL_X and EV_REL REL_Y, once we have both then
  * we accelerate the (x, y) vector and set the EV_REL event's value
@@ -72,8 +70,6 @@ static unsigned int maccel_events(struct input_handle *handle,
 }
 
 static bool maccel_match(struct input_handler *handler, struct input_dev *dev) {
-  if (dev == VIRTUAL_INPUT_DEV)
-    return false;
   if (!dev->dev.parent)
     return false;
 

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -2,56 +2,14 @@
 #include "./usbmouse.h"
 #include "input_echo.h"
 
-// The virtual_input_dev is declared for/in the maccel_input_handler module.
-// This initializes it.
-static int create_virtual_device(void) {
-  int error;
-
-  VIRTUAL_INPUT_DEV = input_allocate_device();
-  if (!VIRTUAL_INPUT_DEV) {
-    printk(KERN_ERR "Failed to allocate virtual input device\n");
-    return -ENOMEM;
-  }
-
-  VIRTUAL_INPUT_DEV->name = "maccel [Virtual Mouse]";
-  VIRTUAL_INPUT_DEV->id.bustype = BUS_USB;
-  /* virtual_input_dev->id.vendor = 0x1234; */
-  /* virtual_input_dev->id.product = 0x5678; */
-  VIRTUAL_INPUT_DEV->id.version = 1;
-
-  // Set the supported event types and codes for the virtual device
-  // and for some reason not setting some EV_KEY bits causes a noticeable
-  // difference in the values we operate on, leading to a different
-  // acceleration behavior than we expect.
-  set_bit(EV_KEY, VIRTUAL_INPUT_DEV->evbit);
-  set_bit(BTN_LEFT, VIRTUAL_INPUT_DEV->keybit);
-
-  set_bit(EV_REL, VIRTUAL_INPUT_DEV->evbit);
-  for (u32 code = REL_X; code < REL_CNT; code++) {
-    set_bit(code, VIRTUAL_INPUT_DEV->relbit);
-  }
-
-  error = input_register_device(VIRTUAL_INPUT_DEV);
-  if (error) {
-    printk(KERN_ERR "Failed to register virtual input device\n");
-    input_free_device(VIRTUAL_INPUT_DEV);
-    return error;
-  }
-
-  return 0;
-}
-
 /*
- * We initialize the virtual_input_dev for input_handler
- * and the usb driver for the usb_mouse driver -
+ * We initialize the usb driver for the usb_mouse driver, and the character
+ * driver for the userspace visualizations.
+ *
  * Some may prefer to bind to this usbmouse driver if their mouse allows.
  */
 static int __init my_init(void) {
   int error;
-  error = create_virtual_device();
-  if (error) {
-    return error;
-  }
   error = usb_register(&maccel_usb_driver);
   if (error)
     goto err_free_vdev;
@@ -73,8 +31,6 @@ err_unregister_usb:
   usb_deregister(&maccel_usb_driver);
 
 err_free_vdev:
-  input_unregister_device(VIRTUAL_INPUT_DEV);
-  input_free_device(VIRTUAL_INPUT_DEV);
   return error;
 }
 
@@ -84,9 +40,6 @@ static void __exit my_exit(void) {
   destroy_char_device();
 
   usb_deregister(&maccel_usb_driver);
-
-  input_unregister_device(VIRTUAL_INPUT_DEV);
-  input_free_device(VIRTUAL_INPUT_DEV);
 }
 
 MODULE_LICENSE("GPL");

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -7,34 +7,34 @@
 static int create_virtual_device(void) {
   int error;
 
-  virtual_input_dev = input_allocate_device();
-  if (!virtual_input_dev) {
+  VIRTUAL_INPUT_DEV = input_allocate_device();
+  if (!VIRTUAL_INPUT_DEV) {
     printk(KERN_ERR "Failed to allocate virtual input device\n");
     return -ENOMEM;
   }
 
-  virtual_input_dev->name = "maccel [Virtual Mouse]";
-  virtual_input_dev->id.bustype = BUS_USB;
+  VIRTUAL_INPUT_DEV->name = "maccel [Virtual Mouse]";
+  VIRTUAL_INPUT_DEV->id.bustype = BUS_USB;
   /* virtual_input_dev->id.vendor = 0x1234; */
   /* virtual_input_dev->id.product = 0x5678; */
-  virtual_input_dev->id.version = 1;
+  VIRTUAL_INPUT_DEV->id.version = 1;
 
   // Set the supported event types and codes for the virtual device
   // and for some reason not setting some EV_KEY bits causes a noticeable
   // difference in the values we operate on, leading to a different
   // acceleration behavior than we expect.
-  set_bit(EV_KEY, virtual_input_dev->evbit);
-  set_bit(BTN_LEFT, virtual_input_dev->keybit);
+  set_bit(EV_KEY, VIRTUAL_INPUT_DEV->evbit);
+  set_bit(BTN_LEFT, VIRTUAL_INPUT_DEV->keybit);
 
-  set_bit(EV_REL, virtual_input_dev->evbit);
+  set_bit(EV_REL, VIRTUAL_INPUT_DEV->evbit);
   for (u32 code = REL_X; code < REL_CNT; code++) {
-    set_bit(code, virtual_input_dev->relbit);
+    set_bit(code, VIRTUAL_INPUT_DEV->relbit);
   }
 
-  error = input_register_device(virtual_input_dev);
+  error = input_register_device(VIRTUAL_INPUT_DEV);
   if (error) {
     printk(KERN_ERR "Failed to register virtual input device\n");
-    input_free_device(virtual_input_dev);
+    input_free_device(VIRTUAL_INPUT_DEV);
     return error;
   }
 
@@ -73,8 +73,8 @@ err_unregister_usb:
   usb_deregister(&maccel_usb_driver);
 
 err_free_vdev:
-  input_unregister_device(virtual_input_dev);
-  input_free_device(virtual_input_dev);
+  input_unregister_device(VIRTUAL_INPUT_DEV);
+  input_free_device(VIRTUAL_INPUT_DEV);
   return error;
 }
 
@@ -85,8 +85,8 @@ static void __exit my_exit(void) {
 
   usb_deregister(&maccel_usb_driver);
 
-  input_unregister_device(virtual_input_dev);
-  input_free_device(virtual_input_dev);
+  input_unregister_device(VIRTUAL_INPUT_DEV);
+  input_free_device(VIRTUAL_INPUT_DEV);
 }
 
 MODULE_LICENSE("GPL");

--- a/driver/mouse_move.h
+++ b/driver/mouse_move.h
@@ -1,0 +1,59 @@
+#include "dbg.h"
+#include "linux/input.h"
+#include <linux/stddef.h>
+
+#define NONE_EVENT_VALUE 0
+
+typedef struct {
+  int *x;
+  int *y;
+} mouse_move;
+
+static mouse_move MOVEMENT = {.x = NULL, .y = NULL};
+
+static inline void update_mouse_move(struct input_value *value) {
+  switch (value->code) {
+  case REL_X:
+    MOVEMENT.x = &value->value;
+    break;
+  case REL_Y:
+    MOVEMENT.y = &value->value;
+    break;
+  default:
+    dbg("bad movement input_value: (code, value) = (%d, %d)", value->code,
+        value->value);
+  }
+}
+
+static inline int get_x(mouse_move movement) {
+  if (movement.x == NULL) {
+    return NONE_EVENT_VALUE;
+  }
+  return *movement.x;
+}
+
+static inline int get_y(mouse_move movement) {
+  if (movement.y == NULL) {
+    return NONE_EVENT_VALUE;
+  }
+  return *movement.y;
+}
+
+static inline void set_x_move(int value) {
+  if (MOVEMENT.x == NULL) {
+    return;
+  }
+  *MOVEMENT.x = value;
+}
+
+static inline void set_y_move(int value) {
+  if (MOVEMENT.y == NULL) {
+    return;
+  }
+  *MOVEMENT.y = value;
+}
+
+static inline void clear_mouse_move(void) {
+  MOVEMENT.x = NULL;
+  MOVEMENT.y = NULL;
+}


### PR DESCRIPTION
Inspired by https://github.com/AndyFilter/YeetMouse/pull/5. They found a way to modify input values directly, so I no longer need a virtual device. 

This makes me confident enough now to just remove the old binding driver.