### PR TITLE
Bump cli version for package Cargo.lock also

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "maccel-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "cc",


### PR DESCRIPTION
The version bump in `/cli/Cargo.toml` conflicts the version in `/Cargo.lock`, and `PKGBUILD` once again fails to compile because of the `--locked` flag on `cargo fetch` at `prepare()`.

Also, is there a reason you're keeping `maccel-tui` and `maccel-core` versions at `0.0.0`?