### PR TITLE
Refactor/`maccel_core::params::persist` -> `maccel_core::persist`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> anyhow::Result<()> {
         },
         CLiCommands::Get { command } => match command {
             CliSubcommandGetParams::Param { name } => {
-                let value = param_store.get(&name)?;
+                let value = param_store.get(name)?;
                 let string_value: &str = (&value).try_into()?;
                 println!("{}", string_value);
             }
@@ -156,7 +156,7 @@ fn print_all_params<'p>(
     let delimiter = if oneline { " " } else { "\n" };
 
     let params = params
-        .map(|p| {
+        .map(|&p| {
             SysFsStore.get(p).and_then(|_p: Fpt| {
                 let value: &str = (&_p).try_into()?;
                 Ok((p.display_name(), value.to_string()))

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,7 +79,7 @@ fn main() -> anyhow::Result<()> {
                     param_store.set_all_synchronous(param_args)?
                 }
             },
-            CliSubcommandSetParams::Mode { mode } => SysFsStore::set_current_accel_mode(mode),
+            CliSubcommandSetParams::Mode { mode } => SysFsStore.set_current_accel_mode(mode)?,
         },
         CLiCommands::Get { command } => match command {
             CliSubcommandGetParams::Param { name } => {
@@ -106,7 +106,7 @@ fn main() -> anyhow::Result<()> {
                 }
             },
             CliSubcommandGetParams::Mode => {
-                let mode = SysFsStore::get_current_accel_mode();
+                let mode = SysFsStore.get_current_accel_mode()?;
                 println!("{}\n", mode.as_title());
                 match mode {
                     AccelMode::Linear => {

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -42,7 +42,7 @@ impl<PS: ParamStore> TuiContext<PS> {
                 .iter()
                 .map(|&p| {
                     let value = parameter_store
-                        .get(&p)
+                        .get(p)
                         .expect("Failed to get a param from store while initializing TuiContext");
                     Parameter::new(p, value)
                 })
@@ -71,7 +71,7 @@ impl<PS: ParamStore> TuiContext<PS> {
         for p in self.parameters.iter_mut() {
             p.value = self
                 .parameter_store
-                .get(&p.tag)
+                .get(p.tag)
                 .expect("failed to read and initialize a parameter's value");
         }
     }

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -7,10 +7,10 @@ use std::{
 use anyhow::Context;
 
 use crate::{
+    AccelMode,
     libmaccel::fixedptc::Fpt,
     params::{AllParamArgs, Param},
     persist::ParamStore,
-    AccelMode,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -35,7 +35,9 @@ pub struct TuiContext<PS: ParamStore> {
 impl<PS: ParamStore> TuiContext<PS> {
     pub fn new(parameter_store: PS, parameters: &[Param]) -> Self {
         Self {
-            current_mode: PS::get_current_accel_mode(),
+            current_mode: parameter_store
+                .get_current_accel_mode()
+                .expect("Failed to get accel mode from store while initializing TuiContext"),
             parameters: parameters
                 .iter()
                 .map(|&p| {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,6 +2,7 @@ mod context;
 pub mod inputspeed;
 mod libmaccel;
 mod params;
+pub mod persist;
 mod sens_fns;
 
 pub use context::*;

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -2,8 +2,6 @@ use crate::libmaccel::fixedptc;
 use crate::libmaccel::fixedptc::Fpt;
 use paste::paste;
 
-use std::{fmt::Display, str::FromStr};
-
 /// Declare an enum for every parameter.
 macro_rules! declare_common_params {
     ($($param:tt,)+) => {
@@ -193,190 +191,6 @@ impl AccelMode {
     }
 }
 
-pub mod persist {
-    use std::{
-        fmt::Debug,
-        io::Read,
-        path::{Path, PathBuf},
-    };
-
-    use anyhow::{anyhow, Context};
-
-    use crate::fixedptc::Fpt;
-
-    use super::*;
-
-    pub trait ParamStore: Debug {
-        fn set(&mut self, param: super::Param, value: f64) -> anyhow::Result<()>;
-        fn get(&self, param: &super::Param) -> anyhow::Result<Fpt>;
-
-        fn set_current_accel_mode(mode: AccelMode);
-        fn get_current_accel_mode() -> AccelMode;
-    }
-
-    const SYS_MODULE_PATH: &str = "/sys/module/maccel";
-
-    #[derive(Debug)]
-    pub struct SysFsStore;
-
-    impl ParamStore for SysFsStore {
-        fn set(&mut self, param: super::Param, value: f64) -> anyhow::Result<()> {
-            use validate::validate_param_value;
-            validate_param_value(param, value)?;
-
-            let value: Fpt = value.into();
-            let value = value.0;
-            set_parameter(param.name(), value)
-        }
-
-        fn get(&self, param: &super::Param) -> anyhow::Result<Fpt> {
-            let value = get_paramater(param.name())?;
-            let value = Fpt::from_str(&value).context(format!(
-                "couldn't interpret the parameter's value {}",
-                value
-            ))?;
-            Ok(value)
-        }
-
-        fn set_current_accel_mode(mode: AccelMode) {
-            set_parameter(AccelMode::PARAM_NAME, mode.ordinal())
-                .expect("Failed to set kernel param to change modes");
-        }
-        fn get_current_accel_mode() -> AccelMode {
-            get_paramater(AccelMode::PARAM_NAME)
-                .map(|mode_tag| {
-                    let id: u8 = mode_tag
-                        .parse()
-                        .expect("Failed to parse an id for mode parameter");
-                    let idx = id as usize % ALL_MODES.len();
-                    ALL_MODES[idx]
-                })
-                .expect("Failed to read a kernel parameter to get the acceleration mode desired")
-        }
-    }
-
-    impl SysFsStore {
-        pub fn set_all_common(&mut self, args: CommonParamArgs) -> anyhow::Result<()> {
-            let CommonParamArgs {
-                sens_mult,
-                yx_ratio,
-                input_dpi,
-            } = args;
-
-            self.set(Param::SensMult, sens_mult)?;
-            self.set(Param::YxRatio, yx_ratio)?;
-            self.set(Param::InputDpi, input_dpi)?;
-
-            Ok(())
-        }
-
-        pub fn set_all_linear(&mut self, args: LinearParamArgs) -> anyhow::Result<()> {
-            let LinearParamArgs {
-                accel,
-                offset_linear,
-                output_cap,
-            } = args;
-
-            self.set(Param::Accel, accel)?;
-            self.set(Param::OffsetLinear, offset_linear)?;
-            self.set(Param::OutputCap, output_cap)?;
-
-            Ok(())
-        }
-
-        pub fn set_all_natural(&mut self, args: NaturalParamArgs) -> anyhow::Result<()> {
-            let NaturalParamArgs {
-                decay_rate,
-                limit,
-                offset_natural,
-            } = args;
-
-            self.set(Param::DecayRate, decay_rate)?;
-            self.set(Param::OffsetNatural, offset_natural)?;
-            self.set(Param::Limit, limit)?;
-
-            Ok(())
-        }
-
-        pub fn set_all_synchronous(&mut self, args: SynchronousParamArgs) -> anyhow::Result<()> {
-            let SynchronousParamArgs {
-                gamma,
-                smooth,
-                motivity,
-                sync_speed,
-            } = args;
-
-            self.set(Param::Gamma, gamma)?;
-            self.set(Param::Smooth, smooth)?;
-            self.set(Param::Motivity, motivity)?;
-            self.set(Param::SyncSpeed, sync_speed)?;
-
-            Ok(())
-        }
-    }
-
-    fn parameter_path(name: &'static str) -> anyhow::Result<PathBuf> {
-        let params_path = Path::new(SYS_MODULE_PATH).join("parameters").join(name);
-
-        if !params_path.exists() {
-            return Err(anyhow!("no such path: {}", params_path.display()))
-                .context(anyhow!("no such parameter {:?}", name));
-        }
-
-        Ok(params_path)
-    }
-
-    fn save_parameter_reset_script(name: &'static str, value: i64) -> anyhow::Result<()> {
-        let script_dir = "/var/opt/maccel/resets";
-        if !Path::new(script_dir).exists() {
-            std::fs::create_dir_all(script_dir).context(format!("failed create directory: {}", script_dir))
-                .context("failed to create the directory where we'd save the parameter value to apply on reboot")?;
-        }
-        std::fs::write(
-            format!("{script_dir}/set_last_{}_value.sh", name),
-            format!("echo {} > /sys/module/maccel/parameters/{};", value, name),
-        )
-        .context("failed to write reset script")?;
-        Ok(())
-    }
-
-    fn get_paramater(name: &'static str) -> anyhow::Result<String> {
-        let path = parameter_path(name)?;
-        let mut file = std::fs::File::open(&path)
-            .context(anyhow!(
-                "failed to open the parameter's file for reading: {}",
-                path.display()
-            ))
-            .context("this shouldn't happen unless the maccel kernel module is not installed.")?;
-
-        let mut buf = String::new();
-
-        file.read_to_string(&mut buf)
-            .context("failed to read the parameter's value")?;
-
-        Ok(buf.trim().to_string())
-    }
-
-    fn set_parameter(name: &'static str, value: i64) -> anyhow::Result<()> {
-        let path = parameter_path(name)?;
-
-        std::fs::write(&path, format!("{}", value)).context(anyhow!(
-            "failed to write to parameter file: {}",
-            path.display()
-        ))?;
-
-        save_parameter_reset_script(name, value)?;
-
-        Ok(())
-    }
-
-    impl Display for Fpt {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str(&format_param_value(f64::from(*self)))
-        }
-    }
-}
-
 impl Param {
     /// The canonical name of the parameter, as defined by the kernel module,
     /// and exactly what can be read from /sys/module/maccel/parameters
@@ -417,7 +231,7 @@ impl Param {
     }
 }
 
-fn format_param_value(value: f64) -> String {
+pub fn format_param_value(value: f64) -> String {
     let mut number = format!("{:.5}", value);
 
     for idx in (1..number.len()).rev() {
@@ -444,57 +258,53 @@ fn format_param_value_works() {
     assert_eq!(format_param_value(0.055000), "0.055");
 }
 
-mod validate {
-    use super::Param;
-
-    pub fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Result<()> {
-        match param_tag {
-            Param::SensMult => {}
-            Param::YxRatio => {}
-            Param::InputDpi => {
-                if value <= 0.0 {
-                    anyhow::bail!("Input DPI must be positive");
-                }
-            }
-            Param::Accel => {}
-            Param::OutputCap => {}
-            Param::OffsetLinear | Param::OffsetNatural => {
-                if value < 0.0 {
-                    anyhow::bail!("offset cannot be less than 0");
-                }
-            }
-            Param::DecayRate => {
-                if value <= 0.0 {
-                    anyhow::bail!("decay rate must be positive");
-                }
-            }
-            Param::Limit => {
-                if value < 1.0 {
-                    anyhow::bail!("limit cannot be less than 1");
-                }
-            }
-            Param::Gamma => {
-                if value <= 0.0 {
-                    anyhow::bail!("Gamma must be positive");
-                }
-            }
-            Param::Smooth => {
-                if !(0.0..=1.0).contains(&value) {
-                    anyhow::bail!("Smooth must be between 0 and 1");
-                }
-            }
-            Param::Motivity => {
-                if value <= 1.0 {
-                    anyhow::bail!("Motivity must be greater than 1");
-                }
-            }
-            Param::SyncSpeed => {
-                if value <= 0.0 {
-                    anyhow::bail!("'Synchronous speed' must be positive");
-                }
+pub fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Result<()> {
+    match param_tag {
+        Param::SensMult => {}
+        Param::YxRatio => {}
+        Param::InputDpi => {
+            if value <= 0.0 {
+                anyhow::bail!("Input DPI must be positive");
             }
         }
-
-        Ok(())
+        Param::Accel => {}
+        Param::OutputCap => {}
+        Param::OffsetLinear | Param::OffsetNatural => {
+            if value < 0.0 {
+                anyhow::bail!("offset cannot be less than 0");
+            }
+        }
+        Param::DecayRate => {
+            if value <= 0.0 {
+                anyhow::bail!("decay rate must be positive");
+            }
+        }
+        Param::Limit => {
+            if value < 1.0 {
+                anyhow::bail!("limit cannot be less than 1");
+            }
+        }
+        Param::Gamma => {
+            if value <= 0.0 {
+                anyhow::bail!("Gamma must be positive");
+            }
+        }
+        Param::Smooth => {
+            if !(0.0..=1.0).contains(&value) {
+                anyhow::bail!("Smooth must be between 0 and 1");
+            }
+        }
+        Param::Motivity => {
+            if value <= 1.0 {
+                anyhow::bail!("Motivity must be greater than 1");
+            }
+        }
+        Param::SyncSpeed => {
+            if value <= 0.0 {
+                anyhow::bail!("'Synchronous speed' must be positive");
+            }
+        }
     }
+
+    Ok(())
 }

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -230,7 +230,7 @@ impl Param {
     }
 }
 
-pub fn format_param_value(value: f64) -> String {
+pub(crate) fn format_param_value(value: f64) -> String {
     let mut number = format!("{:.5}", value);
 
     for idx in (1..number.len()).rev() {
@@ -257,7 +257,7 @@ fn format_param_value_works() {
     assert_eq!(format_param_value(0.055000), "0.055");
 }
 
-pub fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Result<()> {
+pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Result<()> {
     match param_tag {
         Param::SensMult => {}
         Param::YxRatio => {}

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -1,4 +1,3 @@
-use crate::libmaccel::fixedptc;
 use crate::libmaccel::fixedptc::Fpt;
 use paste::paste;
 
@@ -48,7 +47,7 @@ macro_rules! declare_params {
             /// of the sensitivity function as it is expected to be in `C`
             #[repr(C)]
             pub struct AccelParams {
-                $( pub [< $common_param:snake:lower >] : fixedptc::Fpt, )+
+                $( pub [< $common_param:snake:lower >] : Fpt, )+
                 pub by_mode: AccelParamsByMode,
             }
 
@@ -74,7 +73,7 @@ macro_rules! declare_params {
                 /// Represents curve-specific parameters.
                 #[repr(C)]
                 pub struct [< $mode CurveParams >] {
-                    $( pub [< $param:snake:lower >]: fixedptc::Fpt ),+
+                    $( pub [< $param:snake:lower >]: Fpt ),+
                 }
 
                 #[doc = "Array of all parameters for the `"  $mode "` mode for convenience." ]

--- a/crates/core/src/persist.rs
+++ b/crates/core/src/persist.rs
@@ -7,7 +7,13 @@ use std::{
 
 use anyhow::{Context, anyhow};
 
-use crate::{fixedptc::Fpt, params::*};
+use crate::{
+    fixedptc::Fpt,
+    params::{
+        ALL_MODES, AccelMode, CommonParamArgs, LinearParamArgs, NaturalParamArgs, Param,
+        SynchronousParamArgs, format_param_value, validate_param_value,
+    },
+};
 
 pub trait ParamStore: Debug {
     fn set(&mut self, param: Param, value: f64) -> anyhow::Result<()>;

--- a/crates/core/src/persist.rs
+++ b/crates/core/src/persist.rs
@@ -17,7 +17,7 @@ use crate::{
 
 pub trait ParamStore: Debug {
     fn set(&mut self, param: Param, value: f64) -> anyhow::Result<()>;
-    fn get(&self, param: &Param) -> anyhow::Result<Fpt>;
+    fn get(&self, param: Param) -> anyhow::Result<Fpt>;
 
     fn set_current_accel_mode(&mut self, mode: AccelMode) -> anyhow::Result<()>;
     fn get_current_accel_mode(&self) -> anyhow::Result<AccelMode>;
@@ -36,7 +36,7 @@ impl ParamStore for SysFsStore {
         let value = value.0;
         set_parameter(param.name(), value)
     }
-    fn get(&self, param: &Param) -> anyhow::Result<Fpt> {
+    fn get(&self, param: Param) -> anyhow::Result<Fpt> {
         let value = get_paramater(param.name())?;
         let value = Fpt::from_str(&value).context(format!(
             "couldn't interpret the parameter's value {}",

--- a/crates/core/src/persist.rs
+++ b/crates/core/src/persist.rs
@@ -1,0 +1,179 @@
+use std::{
+    fmt::{Debug, Display},
+    io::Read,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{Context, anyhow};
+
+use crate::{fixedptc::Fpt, params::*};
+
+pub trait ParamStore: Debug {
+    fn set(&mut self, param: Param, value: f64) -> anyhow::Result<()>;
+    fn get(&self, param: &Param) -> anyhow::Result<Fpt>;
+
+    fn set_current_accel_mode(mode: AccelMode);
+    fn get_current_accel_mode() -> AccelMode;
+}
+
+const SYS_MODULE_PATH: &str = "/sys/module/maccel";
+
+#[derive(Debug)]
+pub struct SysFsStore;
+
+impl ParamStore for SysFsStore {
+    fn set(&mut self, param: Param, value: f64) -> anyhow::Result<()> {
+        validate_param_value(param, value)?;
+
+        let value: Fpt = value.into();
+        let value = value.0;
+        set_parameter(param.name(), value)
+    }
+
+    fn get(&self, param: &Param) -> anyhow::Result<Fpt> {
+        let value = get_paramater(param.name())?;
+        let value = Fpt::from_str(&value).context(format!(
+            "couldn't interpret the parameter's value {}",
+            value
+        ))?;
+        Ok(value)
+    }
+
+    fn set_current_accel_mode(mode: AccelMode) {
+        set_parameter(AccelMode::PARAM_NAME, mode.ordinal())
+            .expect("Failed to set kernel param to change modes");
+    }
+    fn get_current_accel_mode() -> AccelMode {
+        get_paramater(AccelMode::PARAM_NAME)
+            .map(|mode_tag| {
+                let id: u8 = mode_tag
+                    .parse()
+                    .expect("Failed to parse an id for mode parameter");
+                let idx = id as usize % ALL_MODES.len();
+                ALL_MODES[idx]
+            })
+            .expect("Failed to read a kernel parameter to get the acceleration mode desired")
+    }
+}
+
+impl SysFsStore {
+    pub fn set_all_common(&mut self, args: CommonParamArgs) -> anyhow::Result<()> {
+        let CommonParamArgs {
+            sens_mult,
+            yx_ratio,
+            input_dpi,
+        } = args;
+
+        self.set(Param::SensMult, sens_mult)?;
+        self.set(Param::YxRatio, yx_ratio)?;
+        self.set(Param::InputDpi, input_dpi)?;
+
+        Ok(())
+    }
+
+    pub fn set_all_linear(&mut self, args: LinearParamArgs) -> anyhow::Result<()> {
+        let LinearParamArgs {
+            accel,
+            offset_linear,
+            output_cap,
+        } = args;
+
+        self.set(Param::Accel, accel)?;
+        self.set(Param::OffsetLinear, offset_linear)?;
+        self.set(Param::OutputCap, output_cap)?;
+
+        Ok(())
+    }
+
+    pub fn set_all_natural(&mut self, args: NaturalParamArgs) -> anyhow::Result<()> {
+        let NaturalParamArgs {
+            decay_rate,
+            limit,
+            offset_natural,
+        } = args;
+
+        self.set(Param::DecayRate, decay_rate)?;
+        self.set(Param::OffsetNatural, offset_natural)?;
+        self.set(Param::Limit, limit)?;
+
+        Ok(())
+    }
+
+    pub fn set_all_synchronous(&mut self, args: SynchronousParamArgs) -> anyhow::Result<()> {
+        let SynchronousParamArgs {
+            gamma,
+            smooth,
+            motivity,
+            sync_speed,
+        } = args;
+
+        self.set(Param::Gamma, gamma)?;
+        self.set(Param::Smooth, smooth)?;
+        self.set(Param::Motivity, motivity)?;
+        self.set(Param::SyncSpeed, sync_speed)?;
+
+        Ok(())
+    }
+}
+
+fn parameter_path(name: &'static str) -> anyhow::Result<PathBuf> {
+    let params_path = Path::new(SYS_MODULE_PATH).join("parameters").join(name);
+
+    if !params_path.exists() {
+        return Err(anyhow!("no such path: {}", params_path.display()))
+            .context(anyhow!("no such parameter {:?}", name));
+    }
+
+    Ok(params_path)
+}
+
+fn save_parameter_reset_script(name: &'static str, value: i64) -> anyhow::Result<()> {
+    let script_dir = "/var/opt/maccel/resets";
+    if !Path::new(script_dir).exists() {
+        std::fs::create_dir_all(script_dir).context(format!("failed create directory: {}", script_dir))
+            .context("failed to create the directory where we'd save the parameter value to apply on reboot")?;
+    }
+    std::fs::write(
+        format!("{script_dir}/set_last_{}_value.sh", name),
+        format!("echo {} > /sys/module/maccel/parameters/{};", value, name),
+    )
+    .context("failed to write reset script")?;
+    Ok(())
+}
+
+fn get_paramater(name: &'static str) -> anyhow::Result<String> {
+    let path = parameter_path(name)?;
+    let mut file = std::fs::File::open(&path)
+        .context(anyhow!(
+            "failed to open the parameter's file for reading: {}",
+            path.display()
+        ))
+        .context("this shouldn't happen unless the maccel kernel module is not installed.")?;
+
+    let mut buf = String::new();
+
+    file.read_to_string(&mut buf)
+        .context("failed to read the parameter's value")?;
+
+    Ok(buf.trim().to_string())
+}
+
+fn set_parameter(name: &'static str, value: i64) -> anyhow::Result<()> {
+    let path = parameter_path(name)?;
+
+    std::fs::write(&path, format!("{}", value)).context(anyhow!(
+        "failed to write to parameter file: {}",
+        path.display()
+    ))?;
+
+    save_parameter_reset_script(name, value)?;
+
+    Ok(())
+}
+
+impl Display for Fpt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format_param_value(f64::from(*self)))
+    }
+}

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1,17 +1,17 @@
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
-use maccel_core::get_param_value_from_ctx;
-use maccel_core::persist::ParamStore;
-use maccel_core::persist::SysFsStore;
-use maccel_core::Param;
 use maccel_core::ALL_COMMON_PARAMS;
 use maccel_core::ALL_LINEAR_PARAMS;
 use maccel_core::ALL_MODES;
 use maccel_core::ALL_NATURAL_PARAMS;
 use maccel_core::ALL_SYNCHRONOUS_PARAMS;
-use maccel_core::{AccelMode, ContextRef, TuiContext, ALL_PARAMS};
+use maccel_core::Param;
+use maccel_core::get_param_value_from_ctx;
+use maccel_core::persist::ParamStore;
+use maccel_core::persist::SysFsStore;
+use maccel_core::{ALL_PARAMS, AccelMode, ContextRef, TuiContext};
+use ratatui::Terminal;
 use ratatui::backend::Backend;
 use ratatui::crossterm::event::{DisableMouseCapture, EnableMouseCapture, KeyCode, KeyEventKind};
-use ratatui::Terminal;
 use std::{io, time::Instant};
 use std::{panic, time::Duration};
 use tracing::debug;
@@ -186,7 +186,9 @@ impl App {
         for action in actions.drain(..) {
             if let Action::SetMode(accel_mode) = action {
                 self.context.get_mut().current_mode = accel_mode;
-                SysFsStore::set_current_accel_mode(accel_mode);
+                SysFsStore
+                    .set_current_accel_mode(accel_mode)
+                    .expect("Failed to set accel mode in TUI");
                 self.context.get_mut().reset_current_parameters();
             }
 

--- a/tui/src/utils.rs
+++ b/tui/src/utils.rs
@@ -35,7 +35,7 @@ impl CyclingIdx {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use maccel_core::{fixedptc::Fpt, ContextRef, Parameter};
+    use maccel_core::{ContextRef, Parameter, fixedptc::Fpt};
     use mocks::MockStore;
 
     pub fn new_context() -> (ContextRef<MockStore>, Vec<Parameter>) {
@@ -57,7 +57,7 @@ pub(crate) mod test_utils {
 
     mod mocks {
         use anyhow::Context;
-        use maccel_core::{fixedptc::Fpt, persist::ParamStore, AccelMode, Param};
+        use maccel_core::{AccelMode, Param, fixedptc::Fpt, persist::ParamStore};
 
         #[derive(Debug)]
         pub struct MockStore {
@@ -72,20 +72,23 @@ pub(crate) mod test_utils {
                 Ok(())
             }
 
-            fn get(&self, param: &Param) -> anyhow::Result<Fpt> {
+            fn get(&self, param: Param) -> anyhow::Result<Fpt> {
                 self.list
                     .iter()
-                    .find(|(p, _)| p == param)
+                    .find(|(p, _)| p == &param)
                     .map(|(_, v)| v)
                     .copied()
                     .context("failed to get param")
             }
 
-            fn set_current_accel_mode(_mode: maccel_core::AccelMode) {
+            fn set_current_accel_mode(
+                &mut self,
+                _mode: maccel_core::AccelMode,
+            ) -> anyhow::Result<()> {
                 unimplemented!()
             }
-            fn get_current_accel_mode() -> maccel_core::AccelMode {
-                AccelMode::Linear
+            fn get_current_accel_mode(&self) -> anyhow::Result<maccel_core::AccelMode> {
+                Ok(AccelMode::Linear)
             }
         }
     }


### PR DESCRIPTION
This PR includes BREAKING CHANGES. Though I doubt anyone but myself uses `maccel_core` separately.

As you may be aware, `maccel_core::params::persist` mainly houses definitions for `ParamStore` and `SysFsStore`, a trait for defining behaviour when retrieving and modifying parameters. However the module `persist` seems to bear no more similarity to `params` than, say, `context`, while `params.rs` is quite sizable and a split may be desirable.

At the same time, while I was using `maccel_core` in my sy3c4ll/maccel-gui I noticed quirks and inconsistencies with regards to `persist::ParamStore`, namely that while `get` and `set` took in `self`, `get_current_accel_mode` and `set_current_accel_mode` did not while also panicking on error instead of returning an `anyhow::Result`. This introduced difficulties where I couldn't handle mode switching errors, nor save the mode as a member variable in testing.

This PR addresses these issues.

1. Separate `pub mod persist` in `crates/core/src/params.rs` into its own `crates/core/src/persist.rs`
2. Remove `mod validate` in `crates/core/src/params.rs` and extract contents to `params.rs` while I'm at it, since the module housed only one function which was only necessary for a mysterious `Display` impl for `Fpt` in `persist.rs`...?
3. BREAKING: Change function signatures and implementations of `trait ParamStore` in `persist.rs` as described

I've ensured it works for crates `cli` and `tui` already, there should be no problems there.

RSVP.