### PR TITLE
Add NixOS support ❄️

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,36 @@ curl -fsSL https://www.maccel.org/install.sh | sudo BUILD_CLI_FROM_SOURCE=1 sh
 
 You'll need [`cargo`](https://www.rust-lang.org/tools/install)
 
+### NixOS (Flake)
+
+For NixOS users, maccel provides a flake module that integrates seamlessly with your system configuration. Parameters are configured declaratively and applied directly as kernel module parameters for maximum efficiency.
+
+```nix
+# In your flake.nix inputs
+maccel.url = "github:Gnarus-G/maccel";
+
+# In your configuration
+{inputs, ...}: {
+  imports = [
+    inputs.maccel.nixosModules.default
+  ];
+
+  hardware.maccel = {
+    enable = true;
+    enableCli = true; # Optional: for parameter discovery
+    parameters = {
+      mode = "linear";
+      sensMultiplier = 1.0;
+      acceleration = 0.3;
+      offset = 2.0;
+      outputCap = 2.0;
+    };
+  };
+}
+```
+
+See [README_NIXOS.md](README_NIXOS.md) for detailed setup instructions and all available parameters.
+
 ### Arch (PKGBUILD)
 
 ```sh

--- a/README_NIXOS.md
+++ b/README_NIXOS.md
@@ -1,0 +1,76 @@
+# maccel NixOS Flake
+
+If you're on NixOS, maccel provides a declarative flake module to seamlessly integrate and configure the mouse acceleration driver through your system configuration.
+
+**Benefits of the NixOS module:**
+
+- **Declarative configuration**: All parameters defined in your NixOS config
+- **Direct kernel module parameters**: More efficient than reset scripts approach
+- **No manual setup**: Kernel module, udev rules, and CLI tools installed automatically
+- **Parameter discovery**: Optional CLI/TUI for real-time parameter tuning
+
+## Quick Start
+
+Add to your `flake.nix` inputs:
+
+```nix
+maccel.url = "github:Gnarus-G/maccel";
+```
+
+Create your `maccel.nix` module:
+
+```nix
+{inputs, ...}: {
+  imports = [
+    inputs.maccel.nixosModules.default
+  ];
+
+  hardware.maccel = {
+    enable = true;
+    enableCli = true; # Optional
+
+    parameters = {
+      # Common (all modes)
+      sensMultiplier = 1.0;
+      yxRatio = 1.0;
+      inputDpi = 1000.0;
+      angleRotation = 0.0;
+      mode = "synchronous";
+
+      # Linear mode
+      acceleration = 0.3;
+      offset = 2.0;
+      outputCap = 2.0;
+
+      # Natural mode
+      decayRate = 0.1;
+      offset = 2.0;
+      limit = 1.5;
+
+      # Synchronous mode
+      gamma = 1.0;
+      smooth = 0.5;
+      motivity = 2.5;
+      syncSpeed = 10.0;
+    };
+  };
+
+  # To use maccel CLI/TUI without sudo
+  users.groups.maccel.members = ["your_username"];
+}
+```
+
+## How it Works
+
+### Parameter Management
+
+- **NixOS config**: Parameters are set directly as kernel module parameters at boot for maximum efficiency
+- **CLI/TUI**: When `enableCli = true`, you can use `maccel tui` or `maccel set` for real-time adjustments
+- **Temporary changes**: CLI/TUI modifications are session-only and revert after reboot
+
+### Recommended Workflow
+
+1. **Enable CLI tools**: Set `enableCli = true` for parameter discovery
+2. **Find optimal values**: Use `maccel tui` to experiment with parameters in real-time
+3. **Apply permanently**: Copy your optimal values to `hardware.maccel.parameters` in your NixOS config
+4. **Rebuild system**: Run `sudo nixos-rebuild switch --flake .` to make settings persistent

--- a/README_NIXOS.md
+++ b/README_NIXOS.md
@@ -7,6 +7,7 @@ If you're on NixOS, maccel provides a declarative flake module to seamlessly int
 - **Declarative configuration**: All parameters defined in your NixOS config
 - **Direct kernel module parameters**: More efficient than reset scripts approach
 - **No manual setup**: Kernel module, udev rules, and CLI tools installed automatically
+- **Seamless updates**: Update maccel alongside your system like any other flake
 - **Parameter discovery**: Optional CLI/TUI for real-time parameter tuning
 
 ## Quick Start
@@ -74,3 +75,107 @@ Create your `maccel.nix` module:
 2. **Find optimal values**: Use `maccel tui` to experiment with parameters in real-time
 3. **Apply permanently**: Copy your optimal values to `hardware.maccel.parameters` in your NixOS config
 4. **Rebuild system**: Run `sudo nixos-rebuild switch --flake .` to make settings persistent
+
+## Maintaining the NixOS Module
+
+When new acceleration modes or parameters are added to maccel, the [NixOS module](module.nix) needs to be updated accordingly. This section provides a step-by-step guide for maintainers.
+
+### 1. Adding New Modes
+
+New modes are defined in [`driver/accel/mode.h`](driver/accel/mode.h). To add support:
+
+**In [`module.nix`](module.nix):**
+
+#### Step 1: Add to modeMap
+
+```nix
+# Update the modeMap with new modes
+modeMap = {
+  linear = 0;
+  natural = 1;
+  synchronous = 2;
+  no_accel = 3;
+  new_mode = 4;  # Add new mode here
+};
+```
+
+#### Step 2: Add the mode option
+
+```nix
+# In options.hardware.maccel.parameters
+mode = mkOption {
+  type = types.nullOr (types.enum ["linear" "natural" "synchronous" "no_accel" "new_mode"]);
+  default = null;
+  description = "Acceleration mode.";
+};
+```
+
+### 2. Adding New Parameters
+
+New parameters are defined in [`driver/params.h`](driver/params.h). To add support:
+
+**In [`module.nix`](module.nix):**
+
+#### Step 1: Add to parameterMap
+
+```nix
+# In parameterMap
+parameterMap = {
+  # Existing parameters...
+  NEW_PARAM = cfg.parameters.newParam;
+};
+```
+
+#### Step 2: Add NixOS option
+
+```nix
+# In options.hardware.maccel.parameters
+newParam = mkOption {
+  type = types.nullOr types.float;  # or appropriate type
+  default = null;
+  description = "Description of the new parameter.";
+};
+```
+
+#### Step 3: Add validation (if needed)
+
+```nix
+# For parameters with constraints
+newParam = mkOption {
+  type = types.nullOr (types.addCheck types.float (x: x > 0.0)
+    // {description = "positive float";});
+  default = null;
+  description = "Description of the new parameter. Must be positive.";
+};
+```
+
+### 3. Using LLMs
+
+This NixOS module was developed with significant LLM assistance. Here's a comprehensive prompt for maintaining it:
+
+```
+I need to update the NixOS module for maccel. Please analyze the maccel codebase and help me maintain the NixOS module:
+
+CONTEXT:
+- maccel is a Linux mouse acceleration driver with kernel module and CLI tools
+- The NixOS module is in module.nix and provides declarative configuration
+- Parameters are defined in driver/params.h and modes in driver/accel/mode.h
+- Read README_NIXOS.md section "Maintaining the NixOS Module" for detailed patterns and examples
+
+TASKS:
+1. **Discover changes**: Analyze driver/params.h and driver/accel/ for new parameters, modes, or modifications
+2. **Compare with current**: Check what's missing from existing modeMap and parameterMap in module.nix
+3. **Add new modes**: Update modeMap with correct enum values and add to mode option enum
+4. **Add new parameters**: Add to parameterMap and create NixOS options with proper type validation, descriptions, and constraints
+5. **Explain changes**: Summarize what was added and why
+
+Follow the exact patterns shown in README_NIXOS.md and existing patterns in module.nix. Provide complete code snippets for module.nix.
+```
+
+### 4. Testing The Module
+
+After modifying [`module.nix`](module.nix):
+
+1. **Format nix code**: `alejandra .`
+2. **Check nix syntax**: `nix flake check`
+3. **Test parameter loading**: Confirm parameters load correctly on boot when set via NixOS config

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  description = "maccel NixOS Module";
+
+  outputs = {...}: {
+    nixosModules.default = import ./module.nix;
+  };
+}

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,275 @@
+# NixOS module for maccel mouse acceleration driver
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.hardware.maccel;
+
+  # Extract version from PKGBUILD
+  pkgbuildContent = builtins.readFile ./PKGBUILD;
+  kernelModuleVersion = builtins.head (builtins.match ".*pkgver=([^[:space:]]+).*" pkgbuildContent);
+
+  # Extract version from cli/Cargo.toml
+  cliCargoToml = builtins.fromTOML (builtins.readFile ./cli/Cargo.toml);
+  cliVersion = cliCargoToml.package.version;
+
+  # Convert float to fixed-point integer (64-bit, 32 fractional bits)
+  fixedPointScale = 4294967296; # 2^32
+  toFixedPoint = value: builtins.floor (value * fixedPointScale + 0.5);
+
+  # Mode enum mapping (from driver/accel/mode.h)
+  modeMap = {
+    linear = 0;
+    natural = 1;
+    synchronous = 2;
+    no_accel = 3;
+  };
+
+  # Parameter mapping (from driver/params.h)
+  parameterMap = {
+    # Common parameters
+    SENS_MULT = cfg.parameters.sensMultiplier;
+    YX_RATIO = cfg.parameters.yxRatio;
+    INPUT_DPI = cfg.parameters.inputDpi;
+    ANGLE_ROTATION = cfg.parameters.angleRotation;
+    MODE = cfg.parameters.mode;
+
+    # Linear mode parameters
+    ACCEL = cfg.parameters.acceleration;
+    OFFSET = cfg.parameters.offset;
+    OUTPUT_CAP = cfg.parameters.outputCap;
+
+    # Natural mode parameters
+    DECAY_RATE = cfg.parameters.decayRate;
+    LIMIT = cfg.parameters.limit;
+
+    # Synchronous mode parameters
+    GAMMA = cfg.parameters.gamma;
+    SMOOTH = cfg.parameters.smooth;
+    MOTIVITY = cfg.parameters.motivity;
+    SYNC_SPEED = cfg.parameters.syncSpeed;
+  };
+
+  # Generate modprobe parameter string
+  kernelModuleParams = let
+    validParams = filterAttrs (_: v: v != null) parameterMap;
+    formatParam = name: value:
+      if name == "MODE"
+      then "${name}=${toString (modeMap.${value})}"
+      else "${name}=${toString (toFixedPoint value)}";
+  in
+    concatStringsSep " " (mapAttrsToList formatParam validParams);
+
+  # Build kernel module
+  maccel-kernel-module = config.boot.kernelPackages.callPackage ({
+    lib,
+    stdenv,
+    kernel,
+  }:
+    stdenv.mkDerivation rec {
+      pname = "maccel-dkms";
+      version = kernelModuleVersion;
+
+      src = ./.;
+
+      nativeBuildInputs = kernel.moduleBuildDependencies;
+
+      makeFlags =
+        [
+          "KVER=${kernel.modDirVersion}"
+          "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+          "DRIVER_CFLAGS=-DFIXEDPT_BITS=64"
+        ]
+        ++ optionals cfg.debug ["DRIVER_CFLAGS+=-g -DDEBUG"];
+
+      preBuild = "cd driver";
+
+      installPhase = ''
+        mkdir -p $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/usb
+        cp maccel.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/usb/
+      '';
+
+      meta = with lib; {
+        description = "Mouse acceleration driver and kernel module for Linux.";
+        homepage = "https://www.maccel.org/";
+        license = licenses.gpl2Plus;
+        platforms = platforms.linux;
+      };
+    }) {};
+
+  # Optional CLI tools
+  maccel-cli = pkgs.rustPlatform.buildRustPackage rec {
+    pname = "maccel-cli";
+    version = cliVersion;
+
+    src = ./.;
+
+    cargoLock.lockFile = "${src}/Cargo.lock";
+
+    cargoBuildFlags = ["--bin" "maccel"];
+
+    meta = with lib; {
+      description = "CLI and TUI tools for configuring maccel.";
+      homepage = "https://www.maccel.org/";
+      license = licenses.gpl2Plus;
+      platforms = platforms.linux;
+    };
+  };
+in {
+  options.hardware.maccel = {
+    enable = mkEnableOption "Enable maccel mouse acceleration driver (kernel module). Parameters must be configured via `hardware.maccel.parameters`.";
+
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable debug build of the kernel module.";
+    };
+
+    enableCli = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Install CLI and TUI tools for real-time parameter tuning. You may add your user to the `maccel` group using `users.groups.maccel.members = [\"your_username\"];` to run maccel CLI/TUI without sudo. Note: Changes made via CLI/TUI are temporary and do not persist across reboots. Use this to discover optimal parameter values, then apply them permanently via `hardware.maccel.parameters`.";
+    };
+
+    parameters = {
+      # Common parameters
+      sensMultiplier = mkOption {
+        type = types.nullOr types.float;
+        default = null;
+        description = "Sensitivity multiplier applied after acceleration calculation.";
+      };
+
+      yxRatio = mkOption {
+        type = types.nullOr types.float;
+        default = null;
+        description = "Y/X ratio - factor by which Y-axis sensitivity is multiplied.";
+      };
+
+      inputDpi = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 0.0)
+            // {description = "positive float";});
+        default = null;
+        description = "DPI of the mouse, used to normalize effective DPI. Must be positive.";
+      };
+
+      angleRotation = mkOption {
+        type = types.nullOr types.float;
+        default = null;
+        description = "Apply rotation in degrees to mouse movement input.";
+      };
+
+      mode = mkOption {
+        type = types.nullOr (types.enum ["linear" "natural" "synchronous" "no_accel"]);
+        default = null;
+        description = "Acceleration mode.";
+      };
+
+      # Linear mode parameters
+      acceleration = mkOption {
+        type = types.nullOr types.float;
+        default = null;
+        description = "Linear acceleration factor.";
+      };
+
+      offset = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x >= 0.0)
+            // {description = "non-negative float";});
+        default = null;
+        description = "Input speed past which to allow acceleration. Cannot be negative.";
+      };
+
+      outputCap = mkOption {
+        type = types.nullOr types.float;
+        default = null;
+        description = "Maximum sensitivity multiplier cap.";
+      };
+
+      # Natural mode parameters
+      decayRate = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 0.0)
+            // {description = "positive float";});
+        default = null;
+        description = "Decay rate of the Natural acceleration curve. Must be positive.";
+      };
+
+      limit = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x >= 1.0)
+            // {description = "float >= 1.0";});
+        default = null;
+        description = "Limit of the Natural acceleration curve. Cannot be less than 1.";
+      };
+
+      # Synchronous mode parameters
+      gamma = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 0.0)
+            // {description = "positive float";});
+        default = null;
+        description = "Controls how fast you get from low to fast around the midpoint. Must be positive.";
+      };
+
+      smooth = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x >= 0.0 && x <= 1.0)
+            // {description = "float between 0.0 and 1.0";});
+        default = null;
+        description = "Controls the suddenness of the sensitivity increase. Must be between 0 and 1.";
+      };
+
+      motivity = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 1.0)
+            // {description = "float > 1.0";});
+        default = null;
+        description = "Sets max sensitivity while setting min to 1/motivity. Must be greater than 1.";
+      };
+
+      syncSpeed = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 0.0)
+            // {description = "positive float";});
+        default = null;
+        description = "Sets the middle sensitivity between min and max sensitivity. Must be positive.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Add kernel module
+    boot.extraModulePackages = [maccel-kernel-module];
+
+    # Load module with parameters
+    boot.kernelModules = ["maccel"];
+    boot.extraModprobeConfig = mkIf (kernelModuleParams != "") ''
+      options maccel ${kernelModuleParams}
+    '';
+
+    # Create maccel group
+    users.groups.maccel = {};
+
+    # Install CLI tools if requested
+    environment.systemPackages = mkIf cfg.enableCli [maccel-cli];
+
+    # Create reset scripts directory
+    systemd.tmpfiles.rules = mkIf cfg.enableCli [
+      "d /var/opt/maccel/resets 0775 root maccel"
+    ];
+
+    # Add udev rules
+    services.udev.extraRules = mkIf cfg.enableCli ''
+      # Set sysfs parameter permissions
+      ACTION=="add", SUBSYSTEM=="module", DEVPATH=="/module/maccel", \
+        RUN+="${pkgs.coreutils}/bin/chgrp -R maccel /sys/module/maccel/parameters"
+      # Set /dev/maccel character device permissions
+      ACTION=="add", KERNEL=="maccel", \
+        GROUP="maccel", MODE="0640"
+    '';
+  };
+}


### PR DESCRIPTION
# ❄️ Add NixOS Support

## Summary

This PR adds comprehensive NixOS support to maccel through a flake module, enabling NixOS users to declaratively configure mouse acceleration parameters directly in their system configuration with all parameters support.

## Motivation

NixOS users have been unable to easily use maccel due to the imperative installation process and lack of declarative configuration options. This addition brings maccel to the NixOS ecosystem with first-class support, making it accessible to thousands of NixOS users who prefer declarative system management.

## Features

### 🎯 **Declarative Configuration**

- All acceleration parameters configurable through `hardware.maccel.parameters`
- Parameters applied directly as kernel module parameters for maximum efficiency
- Type-safe configuration with proper validation
- No manual kernel module or udev rule installation required

### 🔧 **Optional CLI/TUI Integration**

- `enableCli` option to install CLI tools for parameter discovery
- Real-time parameter tuning with `maccel tui`
- Session-only changes that don't interfere with NixOS config
- Seamless workflow: experiment with CLI → apply permanently via config

### 📦 **Complete Integration**

- Automatic kernel module building and loading
- Proper udev rules and permissions setup
- User group management (`maccel` group)
- Debug build support via `debug` option
- Optional CLI/TUI for parameter discovery

### ⚡ **Enhanced Efficiency**

- Direct kernel module parameter approach (vs reset scripts used in standard installation)
- Parameters revert to declared values after reboot

## Implementation

### Files Added

- `flake.nix` - Simple flake exporting the NixOS module
- `module.nix` - Full NixOS module with all possible configuration support
- `README_NIXOS.md` - Detailed NixOS-specific documentation

### Key Components

- **Kernel Module Build**: Integrates with NixOS kernel package system
- **Fixed-Point Conversion**: Automatic conversion of float parameters to kernel-compatible fixed-point integers
- **Parameter Mapping**: Complete mapping of all driver parameters to NixOS options
- **CLI Integration**: Optional Rust package building for CLI tools

## Usage Example

```nix
# flake.nix
{
  inputs.maccel.url = "github:Gnarus-G/maccel";
}

# configuration.nix
{inputs, ...}: {
  imports = [inputs.maccel.nixosModules.default];

  hardware.maccel = {
    enable = true;
    enableCli = true;  # Optional

    parameters = {
      mode = "linear";
      sensMultiplier = 1.0;
      acceleration = 0.3;
      offset = 2.0;
      outputCap = 2.0;
    };
  };

  users.groups.maccel.members = ["username"];  # For CLI access without sudo
}
```

## Workflow Benefits

1. **Discovery**: Use `maccel tui` to find optimal parameters in real-time
2. **Configuration**: Apply discovered values permanently in NixOS config
3. **Persistence**: Parameters automatically load on every boot via kernel module parameters
4. **Reproducibility**: Identical configuration across multiple machines

## Documentation Updates

- **README.md**: Added NixOS installation section with concise example
- **README_NIXOS.md**: Comprehensive NixOS-specific guide with:
  - Quick start instructions
  - Parameter management explanation
  - Recommended workflow
  - All available options

## Testing Considerations

The module has been tested with:

- ✅ Kernel module compilation and loading
- ✅ Parameter application and persistence
- ✅ CLI tool functionality when enabled
- ✅ Proper permissions and group setup
- ✅ All acceleration modes (linear, natural, synchronous, no_accel)

## Impact

This addition makes maccel accessible to the growing NixOS community while maintaining the same powerful functionality users expect. The declarative approach aligns perfectly with NixOS philosophy and provides a superior user experience compared to imperative installation methods.

## Related

- Closes potential NixOS user requests
- Enables inclusion in NixOS package collections
- Positions maccel as the most complete mouse acceleration solution for Linux

---

**Ready for the NixOS community! 🚀**
