### PR TITLE
Add classic acceleration mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ The more general function, which is relevant with a set input offset, is:
 
 $$(dx_f, dy_f) = (dx_0, dy_0) * (1 + a * (V - offset_in)^2 / V)$$
 
+## Classic Acceleration Function
+
+Classic acceleration generalizes the linear curve by making the exponent
+configurable:
+
+$$(dx_f, dy_f) = (dx_0, dy_0) * (1 + a * (V - offset_in)^e / V)$$
+
+The `exponent` parameter defaults to `3`. Setting it to `2` matches the linear
+curve shape; values above `2` ramp up more aggressively at high input speeds.
+
 ## Other Curves
 
 - [x] **Natural**
@@ -28,6 +38,8 @@ $$(dx_f, dy_f) = (dx_0, dy_0) * (1 + a * (V - offset_in)^2 / V)$$
 
 - [x] **Synchronous**
       ![image](https://github.com/user-attachments/assets/cd0aefaa-43d1-4f31-8326-334fac2a2210)
+
+- [x] **Classic**
 
 - [ ] **Look up table**
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ configurable:
 $$(dx_f, dy_f) = (dx_0, dy_0) * (1 + a * (V - offset_in)^e / V)$$
 
 The `exponent` parameter defaults to `3`. Setting it to `2` matches the linear
-curve shape; values above `2` ramp up more aggressively at high input speeds.
+curve shape; values between `1` and `2` ramp more gently than linear, while
+values above `2` ramp up more aggressively at high input speeds.
 
 ## Other Curves
 

--- a/README_NIXOS.md
+++ b/README_NIXOS.md
@@ -43,6 +43,9 @@ Create your `maccel.nix` module:
       offset = 2.0;
       outputCap = 2.0;
 
+      # Classic mode
+      exponent = 3.0;
+
       # Natural mode
       decayRate = 0.1;
       offset = 2.0;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,8 +4,8 @@ use maccel_core::{
     fixedptc::Fpt,
     persist::{ParamStore, SysFsStore},
     subcommads::*,
-    AccelMode, NoAccelParamArgs, Param, ALL_COMMON_PARAMS, ALL_LINEAR_PARAMS, ALL_NATURAL_PARAMS,
-    ALL_SYNCHRONOUS_PARAMS,
+    AccelMode, NoAccelParamArgs, Param, ALL_CLASSIC_PARAMS, ALL_COMMON_PARAMS, ALL_LINEAR_PARAMS,
+    ALL_NATURAL_PARAMS, ALL_SYNCHRONOUS_PARAMS,
 };
 use maccel_tui::run_tui;
 
@@ -84,6 +84,9 @@ fn main() -> anyhow::Result<()> {
                     );
                     eprintln!();
                 }
+                SetParamByModesSubcommands::Classic(param_args) => {
+                    param_store.set_all_classic(param_args)?
+                }
             },
             CliSubcommandSetParams::Mode { mode } => SysFsStore.set_current_accel_mode(mode)?,
         },
@@ -117,6 +120,9 @@ fn main() -> anyhow::Result<()> {
                     eprintln!();
                     print_all_params(ALL_COMMON_PARAMS.iter(), oneline, quiet)?;
                 }
+                GetParamsByModesSubcommands::Classic => {
+                    print_all_params(ALL_CLASSIC_PARAMS.iter(), oneline, quiet)?;
+                }
             },
             CliSubcommandGetParams::Mode => {
                 let mode = SysFsStore.get_current_accel_mode()?;
@@ -137,6 +143,9 @@ fn main() -> anyhow::Result<()> {
                         );
                         eprintln!();
                         print_all_params(ALL_COMMON_PARAMS.iter(), false, false)?;
+                    }
+                    AccelMode::Classic => {
+                        print_all_params(ALL_CLASSIC_PARAMS.iter(), false, false)?;
                     }
                 }
             }

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -193,6 +193,12 @@ declare_params!(
         SyncSpeed,
     },
     NoAccel {},
+    Classic {
+        ClassicAccel,
+        OffsetClassic,
+        ClassicOutputCap,
+        Exponent,
+    },
 );
 
 impl AccelMode {
@@ -202,6 +208,7 @@ impl AccelMode {
             AccelMode::Natural => "Natural (w/ Gain)",
             AccelMode::Synchronous => "Synchronous",
             AccelMode::NoAccel => "No Acceleration",
+            AccelMode::Classic => "Classic Acceleration",
         }
     }
 }
@@ -223,15 +230,19 @@ impl Param {
             Param::YxRatio => "YX_RATIO",
             Param::InputDpi => "INPUT_DPI",
             Param::Accel => "ACCEL",
+            Param::ClassicAccel => "ACCEL",
             Param::OffsetLinear => "OFFSET",
             Param::OffsetNatural => "OFFSET",
+            Param::OffsetClassic => "OFFSET",
             Param::OutputCap => "OUTPUT_CAP",
+            Param::ClassicOutputCap => "OUTPUT_CAP",
             Param::DecayRate => "DECAY_RATE",
             Param::Limit => "LIMIT",
             Param::Gamma => "GAMMA",
             Param::Smooth => "SMOOTH",
             Param::Motivity => "MOTIVITY",
             Param::SyncSpeed => "SYNC_SPEED",
+            Param::Exponent => "EXPONENT",
             Param::AngleRotation => "ANGLE_ROTATION",
         }
     }
@@ -240,10 +251,13 @@ impl Param {
         match self {
             Param::SensMult => "Sens-Multiplier",
             Param::Accel => "Accel",
+            Param::ClassicAccel => "Accel",
             Param::InputDpi => "Input DPI",
             Param::OffsetLinear => "Offset",
             Param::OffsetNatural => "Offset",
+            Param::OffsetClassic => "Offset",
             Param::OutputCap => "Output-Cap",
+            Param::ClassicOutputCap => "Output-Cap",
             Param::YxRatio => "Y/x Ratio",
             Param::DecayRate => "Decay-Rate",
             Param::Limit => "Limit",
@@ -251,6 +265,7 @@ impl Param {
             Param::Smooth => "Smooth",
             Param::Motivity => "Motivity",
             Param::SyncSpeed => "Sync Speed",
+            Param::Exponent => "Exponent",
             Param::AngleRotation => "Angle Rotation",
         }
     }
@@ -266,8 +281,17 @@ impl Param {
             }
             Param::AngleRotation => "Rotation angle in degrees for sensitivity direction.",
             Param::Accel => "Acceleration strength. Higher values = faster cursor at high speeds.",
+            Param::ClassicAccel => {
+                "Classic acceleration strength. Higher values = faster cursor at high speeds."
+            }
             Param::OffsetLinear => "Speed threshold (counts/ms) before acceleration begins.",
+            Param::OffsetClassic => {
+                "Speed threshold (counts/ms) before classic acceleration begins."
+            }
             Param::OutputCap => "Maximum sensitivity multiplier cap. Prevents excessive speed.",
+            Param::ClassicOutputCap => {
+                "Maximum classic sensitivity multiplier cap. Prevents excessive speed."
+            }
             Param::DecayRate => "How quickly acceleration decays. Higher = faster decay.",
             Param::OffsetNatural => "Speed threshold (counts/ms) for natural curve activation.",
             Param::Limit => "Maximum gain limit for natural acceleration.",
@@ -275,6 +299,7 @@ impl Param {
             Param::Smooth => "Smoothing factor (0-1). Higher = more gradual transitions.",
             Param::Motivity => "Degree of acceleration effect. Must be > 1.",
             Param::SyncSpeed => "Synchronization speed. Controls how fast sync responds.",
+            Param::Exponent => "Classic curve exponent. Values above 2 ramp up more aggressively.",
         }
     }
 }
@@ -316,9 +341,9 @@ pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Resu
             }
         }
         Param::AngleRotation => {}
-        Param::Accel => {}
-        Param::OutputCap => {}
-        Param::OffsetLinear | Param::OffsetNatural => {
+        Param::Accel | Param::ClassicAccel => {}
+        Param::OutputCap | Param::ClassicOutputCap => {}
+        Param::OffsetLinear | Param::OffsetNatural | Param::OffsetClassic => {
             if value < 0.0 {
                 anyhow::bail!("offset cannot be less than 0");
             }
@@ -351,6 +376,11 @@ pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Resu
         Param::SyncSpeed => {
             if value <= 0.0 {
                 anyhow::bail!("'Synchronous speed' must be positive");
+            }
+        }
+        Param::Exponent => {
+            if value <= 1.0 {
+                anyhow::bail!("Classic exponent must be greater than 1");
             }
         }
     }

--- a/crates/core/src/persist.rs
+++ b/crates/core/src/persist.rs
@@ -10,8 +10,8 @@ use anyhow::{Context, anyhow};
 use crate::{
     fixedptc::Fpt,
     params::{
-        ALL_MODES, AccelMode, CommonParamArgs, LinearParamArgs, NaturalParamArgs, Param,
-        SynchronousParamArgs, format_param_value, validate_param_value,
+        ALL_MODES, AccelMode, ClassicParamArgs, CommonParamArgs, LinearParamArgs, NaturalParamArgs,
+        Param, SynchronousParamArgs, format_param_value, validate_param_value,
     },
 };
 
@@ -128,6 +128,22 @@ impl SysFsStore {
         self.set(Param::Smooth, smooth)?;
         self.set(Param::Motivity, motivity)?;
         self.set(Param::SyncSpeed, sync_speed)?;
+
+        Ok(())
+    }
+
+    pub fn set_all_classic(&mut self, args: ClassicParamArgs) -> anyhow::Result<()> {
+        let ClassicParamArgs {
+            classic_accel,
+            offset_classic,
+            classic_output_cap,
+            exponent,
+        } = args;
+
+        self.set(Param::ClassicAccel, classic_accel)?;
+        self.set(Param::OffsetClassic, offset_classic)?;
+        self.set(Param::ClassicOutputCap, classic_output_cap)?;
+        self.set(Param::Exponent, exponent)?;
 
         Ok(())
     }

--- a/crates/core/src/sens_fns.rs
+++ b/crates/core/src/sens_fns.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AccelParams, AccelParamsByMode, LinearCurveParams, NaturalCurveParams, SynchronousCurveParams,
+    AccelParams, AccelParamsByMode, ClassicCurveParams, LinearCurveParams, NaturalCurveParams,
+    SynchronousCurveParams,
     libmaccel::{self, fixedptc::Fpt},
     params::AllParamArgs,
 };
@@ -28,6 +29,12 @@ impl AllParamArgs {
             AccelMode::NoAccel => {
                 AccelParamsByMode::NoAccel(crate::params::NoAccelCurveParams { _ffi_guard: [] })
             }
+            AccelMode::Classic => AccelParamsByMode::Classic(ClassicCurveParams {
+                classic_accel: self.classic_accel,
+                offset_classic: self.offset_classic,
+                classic_output_cap: self.classic_output_cap,
+                exponent: self.exponent,
+            }),
         };
 
         AccelParams {

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -1,6 +1,7 @@
 #ifndef _ACCEL_H_
 #define _ACCEL_H_
 
+#include "accel/classic.h"
 #include "accel/linear.h"
 #include "accel/mode.h"
 #include "accel/natural.h"
@@ -17,6 +18,7 @@ union __accel_args {
   struct linear_curve_args linear;
   struct synchronous_curve_args synchronous;
   struct no_accel_curve_args no_accel;
+  struct classic_curve_args classic;
 };
 
 struct accel_args {
@@ -52,6 +54,10 @@ static inline struct vector sensitivity(fpt input_speed,
   case linear:
     dbg("accel mode %d: linear", args.tag);
     sens = __linear_sens_fun(input_speed, args.args.linear);
+    break;
+  case classic:
+    dbg("accel mode %d: classic", args.tag);
+    sens = __classic_sens_fun(input_speed, args.args.classic);
     break;
   case no_accel:
     dbg("accel mode %d: no_accel", args.tag);

--- a/driver/accel/classic.h
+++ b/driver/accel/classic.h
@@ -1,0 +1,56 @@
+#ifndef __ACCEL_CLASSIC_H_
+#define __ACCEL_CLASSIC_H_
+
+#include "../dbg.h"
+#include "../fixedptc.h"
+#include "../math.h"
+
+struct classic_curve_args {
+  fpt accel;
+  fpt offset;
+  fpt output_cap;
+  fpt exponent;
+};
+
+static inline fpt classic_base_fn(fpt x, fpt accel, fpt input_offset,
+                                  fpt exponent) {
+  fpt _x = x - input_offset;
+  fpt _x_exp = fpt_pow(_x, exponent);
+  return fpt_mul(accel, fpt_div(_x_exp, x));
+}
+
+/**
+ * Sensitivity Function for Classic Acceleration
+ */
+static inline fpt __classic_sens_fun(fpt input_speed,
+                                     struct classic_curve_args args) {
+  dbg("classic: accel            %s", fptoa(args.accel));
+  dbg("classic: offset           %s", fptoa(args.offset));
+  dbg("classic: output_cap       %s", fptoa(args.output_cap));
+  dbg("classic: exponent         %s", fptoa(args.exponent));
+
+  if (input_speed <= args.offset) {
+    return FIXEDPT_ONE;
+  }
+
+  if (args.exponent <= FIXEDPT_ONE) {
+    return FIXEDPT_ONE;
+  }
+
+  fpt sens =
+      classic_base_fn(input_speed, args.accel, args.offset, args.exponent);
+
+  fpt sign = FIXEDPT_ONE;
+  if (args.output_cap > 0) {
+    fpt cap = fpt_sub(args.output_cap, FIXEDPT_ONE);
+    if (cap < 0) {
+      cap = -cap;
+      sign = -sign;
+    }
+    sens = minsd(sens, cap);
+  }
+
+  return fpt_add(FIXEDPT_ONE, fpt_mul(sign, sens));
+}
+
+#endif // !__ACCEL_CLASSIC_H_

--- a/driver/accel/mode.h
+++ b/driver/accel/mode.h
@@ -1,6 +1,6 @@
 #ifndef __ACCEL_MODE_H
 #define __ACCEL_MODE_H
 
-enum accel_mode : unsigned char { linear, natural, synchronous, no_accel };
+enum accel_mode : unsigned char { linear, natural, synchronous, no_accel, classic };
 
 #endif // !__ACCEL_MODE_H

--- a/driver/accel_k.h
+++ b/driver/accel_k.h
@@ -40,6 +40,13 @@ static struct accel_args collect_args(void) {
     accel.args.linear.output_cap = atofp(PARAM_OUTPUT_CAP);
     break;
   }
+  case classic: {
+    accel.args.classic.accel = atofp(PARAM_ACCEL);
+    accel.args.classic.offset = atofp(PARAM_OFFSET);
+    accel.args.classic.output_cap = atofp(PARAM_OUTPUT_CAP);
+    accel.args.classic.exponent = atofp(PARAM_EXPONENT);
+    break;
+  }
   case no_accel:
   default: {
   }

--- a/driver/params.h
+++ b/driver/params.h
@@ -41,6 +41,16 @@ PARAM(ACCEL, 0, "Control the sensitivity calculation.");
 PARAM(OFFSET, 0, "Input speed threshold (counts/ms) before acceleration begins.");
 PARAM(OUTPUT_CAP, 0, "Control the maximum sensitivity.");
 
+// For Classic Mode
+
+#if FIXEDPT_BITS == 64
+PARAM(EXPONENT, 12884901888, // 3 << 32
+      "Exponent used by the Classic curve.");
+#else
+PARAM(EXPONENT, 196608, // 3 << 16
+      "Exponent used by the Classic curve.");
+#endif
+
 // For Natural Mode
 
 #if FIXEDPT_BITS == 64

--- a/driver/tests/accel.test.c
+++ b/driver/tests/accel.test.c
@@ -202,6 +202,7 @@ int main(void) {
 
   test_synchronous(1, 1.15, 0.8, 0.5, 1.5, 32);
 
+  test_classic(1, 1, 0.3, 2, 2, 2);
   test_classic(1, 1, 0.001, 2, 3, 3);
   test_classic(0.7, 1.2, 0.0001, 5, 2.5, 4);
 

--- a/driver/tests/accel.test.c
+++ b/driver/tests/accel.test.c
@@ -91,6 +91,27 @@ static int test_synchronous_acceleration(const char *filename,
   return test_acceleration(filename, args);
 }
 
+static int test_classic_acceleration(const char *filename, fpt param_sens_mult,
+                                     fpt param_yx_ratio, fpt param_accel,
+                                     fpt param_offset, fpt param_output_cap,
+                                     fpt param_exponent) {
+  struct classic_curve_args _args =
+      (struct classic_curve_args){.accel = param_accel,
+                                  .offset = param_offset,
+                                  .output_cap = param_output_cap,
+                                  .exponent = param_exponent};
+
+  struct accel_args args = {
+      .sens_mult = param_sens_mult,
+      .yx_ratio = param_yx_ratio,
+      .input_dpi = fpt_fromint(1000),
+      .tag = classic,
+      .args = (union __accel_args){.classic = _args},
+  };
+
+  return test_acceleration(filename, args);
+}
+
 static int test_no_accel_acceleration(const char *filename, fpt param_sens_mult,
                                       fpt param_yx_ratio) {
   struct no_accel_curve_args _args = (struct no_accel_curve_args){};
@@ -147,6 +168,13 @@ static int test_rotation_no_accel(const char *filename, fpt param_sens_mult,
              fpt_rconst(smooth), fpt_rconst(motivity),                         \
              fpt_rconst(sync_speed)) == 0);
 
+#define test_classic(sens_mult, yx_ratio, accel, offset, cap, exponent)        \
+  assert(test_classic_acceleration(                                            \
+             "Classic__SENS_MULT-" #sens_mult "-ACCEL-" #accel "-OFFSET"      \
+             #offset "-OUTPUT_CAP-" #cap "-EXPONENT-" #exponent ".snapshot",  \
+             fpt_rconst(sens_mult), fpt_rconst(yx_ratio), fpt_rconst(accel),   \
+             fpt_rconst(offset), fpt_rconst(cap), fpt_rconst(exponent)) == 0);
+
 #define test_no_accel(sens_mult, yx_ratio)                                     \
   assert(test_no_accel_acceleration(                                           \
              "NoAccel__SENS_MULT-" #sens_mult "-YX_RATIO-" #yx_ratio           \
@@ -173,6 +201,9 @@ int main(void) {
   test_natural(1, 1, 0.03, 8, 1.5);
 
   test_synchronous(1, 1.15, 0.8, 0.5, 1.5, 32);
+
+  test_classic(1, 1, 0.001, 2, 3, 3);
+  test_classic(0.7, 1.2, 0.0001, 5, 2.5, 4);
 
   test_no_accel(1, 1);
   test_no_accel(0.5, 1.5);

--- a/module.nix
+++ b/module.nix
@@ -26,6 +26,7 @@ with lib; let
     natural = 1;
     synchronous = 2;
     no_accel = 3;
+    classic = 4;
   };
 
   # Parameter mapping (from driver/params.h)
@@ -41,6 +42,7 @@ with lib; let
     ACCEL = cfg.parameters.acceleration;
     OFFSET = cfg.parameters.offset;
     OUTPUT_CAP = cfg.parameters.outputCap;
+    EXPONENT = cfg.parameters.exponent;
 
     # Natural mode parameters
     DECAY_RATE = cfg.parameters.decayRate;
@@ -163,7 +165,7 @@ in {
       };
 
       mode = mkOption {
-        type = types.nullOr (types.enum ["linear" "natural" "synchronous" "no_accel"]);
+        type = types.nullOr (types.enum ["linear" "natural" "synchronous" "no_accel" "classic"]);
         default = null;
         description = "Acceleration mode.";
       };
@@ -237,6 +239,14 @@ in {
             // {description = "positive float";});
         default = null;
         description = "Sets the middle sensitivity between min and max sensitivity. Must be positive.";
+      };
+
+      exponent = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 1.0)
+            // {description = "float > 1.0";});
+        default = null;
+        description = "Classic curve exponent. Values above 2 ramp up more aggressively.";
       };
     };
   };

--- a/module.nix
+++ b/module.nix
@@ -42,6 +42,8 @@ with lib; let
     ACCEL = cfg.parameters.acceleration;
     OFFSET = cfg.parameters.offset;
     OUTPUT_CAP = cfg.parameters.outputCap;
+
+    # Classic mode parameters
     EXPONENT = cfg.parameters.exponent;
 
     # Natural mode parameters

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -1,4 +1,5 @@
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+use maccel_core::ALL_CLASSIC_PARAMS;
 use maccel_core::ALL_COMMON_PARAMS;
 use maccel_core::ALL_LINEAR_PARAMS;
 use maccel_core::ALL_MODES;
@@ -106,6 +107,20 @@ impl App {
                                 f64::from(get_param_value_from_ctx!(ctx, SensMult)) * 2.0; // No other factor, sens is 1.0
 
                             [0.0, upper_bound.max(1.0)] // Ensure at least a small visible range
+                        }),
+                    ),
+                ),
+                Screen::new(
+                    AccelMode::Classic,
+                    collect_inputs_for_params(ALL_CLASSIC_PARAMS, context.clone()),
+                    Box::new(
+                        SensitivityGraph::new(context.clone()).on_y_axix_bounds_update(|ctx| {
+                            let upper_bound = f64::from(get_param_value_from_ctx!(ctx, SensMult))
+                                * f64::from(get_param_value_from_ctx!(ctx, ClassicOutputCap))
+                                    .max(1.0)
+                                * 2.0;
+
+                            [0.0, upper_bound]
                         }),
                     ),
                 ),


### PR DESCRIPTION
## Summary
- add a Classic acceleration mode backed by a configurable exponent
- wire the mode through the kernel driver, sysfs params, CLI, TUI, Rust parameter structs, and NixOS module
- document the curve and add driver snapshot coverage

Closes #111.

## Validation
- `make test`
- `cargo fmt --all --check`
- `git diff --check`

## Notes
- `cargo test --all` cannot complete on my local macOS aarch64 machine because the existing `crates/core/build.rs` only allows x86/x86_64 and panics with `unsupported/untested architecture: aarch64`.
- `nix` is not installed in this local environment, so I could not run `nix flake check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Classic acceleration mode with configurable curve exponent parameter
  * Enabled Classic mode support in CLI, TUI, and module configuration

* **Documentation**
  * Updated README documenting Classic acceleration function and parameters
  * Added NixOS module configuration example for Classic mode

* **Tests**
  * Added test coverage for Classic acceleration curve behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gnarus-G/maccel/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->