### PR TITLE
Add Synchronous Gain acceleration mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "maccel-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cc",

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=maccel-dkms
 _pkgname="maccel"
-pkgver=0.5.8
+pkgver=0.5.9
 pkgrel=1
 pkgdesc="Mouse acceleration driver and kernel module for Linux."
 arch=("x86_64")

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=maccel-dkms
 _pkgname="maccel"
-pkgver=0.5.9
+pkgver=0.6.0
 pkgrel=1
 pkgdesc="Mouse acceleration driver and kernel module for Linux."
 arch=("x86_64")

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ $$(dx_f, dy_f) = (dx_0, dy_0) * (1 + a * (V - offset_in)^2 / V)$$
 - [x] **Synchronous**
       ![image](https://github.com/user-attachments/assets/cd0aefaa-43d1-4f31-8326-334fac2a2210)
 
+      Set `GAIN` to `1` to interpret the Synchronous curve as the slope of
+      output velocity rather than sensitivity. The driver integrates that
+      curve using the same logarithmic lookup method as Raw Accel:
+
+      ```sh
+      maccel set param gain 1
+      ```
+
 - [ ] **Look up table**
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ $$(dx_f, dy_f) = (dx_0, dy_0) * (1 + a * (V - offset_in)^2 / V)$$
 - [x] **Synchronous**
       ![image](https://github.com/user-attachments/assets/cd0aefaa-43d1-4f31-8326-334fac2a2210)
 
-      Set `GAIN` to `1` to interpret the Synchronous curve as the slope of
-      output velocity rather than sensitivity. The driver integrates that
-      curve using the same logarithmic lookup method as Raw Accel:
+- [x] **Synchronous Gain**
+
+      Synchronous Gain interprets the curve as the slope of output velocity
+      rather than sensitivity. The driver integrates that curve using the same
+      logarithmic lookup method as Raw Accel:
 
       ```sh
-      maccel set param gain 1
+      maccel set mode synchronous-gain
       ```
 
 - [ ] **Look up table**

--- a/README_NIXOS.md
+++ b/README_NIXOS.md
@@ -53,7 +53,12 @@ Create your `maccel.nix` module:
       smooth = 0.5;
       motivity = 2.5;
       syncSpeed = 10.0;
-      gain = true;
+
+      # Synchronous Gain mode
+      syncGainGamma = 1.0;
+      syncGainSmooth = 0.5;
+      syncGainMotivity = 2.5;
+      syncGainSpeed = 10.0;
     };
   };
 

--- a/README_NIXOS.md
+++ b/README_NIXOS.md
@@ -53,6 +53,7 @@ Create your `maccel.nix` module:
       smooth = 0.5;
       motivity = 2.5;
       syncSpeed = 10.0;
+      gain = true;
     };
   };
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maccel-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [[bin]]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use maccel_core::{
     persist::{ParamStore, SysFsStore},
     subcommads::*,
     AccelMode, NoAccelParamArgs, Param, ALL_COMMON_PARAMS, ALL_LINEAR_PARAMS, ALL_NATURAL_PARAMS,
-    ALL_SYNCHRONOUS_PARAMS,
+    ALL_SYNCHRONOUS_GAIN_PARAMS, ALL_SYNCHRONOUS_PARAMS,
 };
 use maccel_tui::run_tui;
 
@@ -78,6 +78,9 @@ fn main() -> anyhow::Result<()> {
                 SetParamByModesSubcommands::Synchronous(param_args) => {
                     param_store.set_all_synchronous(param_args)?
                 }
+                SetParamByModesSubcommands::SynchronousGain(param_args) => {
+                    param_store.set_all_synchronous_gain(param_args)?
+                }
                 SetParamByModesSubcommands::NoAccel(NoAccelParamArgs {}) => {
                     eprintln!(
                         "NOTE: There are no parameters specific here except for the common ones."
@@ -110,6 +113,9 @@ fn main() -> anyhow::Result<()> {
                 GetParamsByModesSubcommands::Synchronous => {
                     print_all_params(ALL_SYNCHRONOUS_PARAMS.iter(), oneline, quiet)?;
                 }
+                GetParamsByModesSubcommands::SynchronousGain => {
+                    print_all_params(ALL_SYNCHRONOUS_GAIN_PARAMS.iter(), oneline, quiet)?;
+                }
                 GetParamsByModesSubcommands::NoAccel => {
                     eprintln!(
                         "NOTE: There are no parameters specific here except for the common ones."
@@ -130,6 +136,9 @@ fn main() -> anyhow::Result<()> {
                     }
                     AccelMode::Synchronous => {
                         print_all_params(ALL_SYNCHRONOUS_PARAMS.iter(), false, false)?;
+                    }
+                    AccelMode::SynchronousGain => {
+                        print_all_params(ALL_SYNCHRONOUS_GAIN_PARAMS.iter(), false, false)?;
                     }
                     AccelMode::NoAccel => {
                         eprintln!(

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -102,6 +102,7 @@ impl<PS: ParamStore> TuiContext<PS> {
             smooth: get!(Smooth),
             motivity: get!(Motivity),
             sync_speed: get!(SyncSpeed),
+            gain: get!(Gain),
             angle_rotation: get!(AngleRotation),
         }
     }

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -102,7 +102,10 @@ impl<PS: ParamStore> TuiContext<PS> {
             smooth: get!(Smooth),
             motivity: get!(Motivity),
             sync_speed: get!(SyncSpeed),
-            gain: get!(Gain),
+            sync_gain_gamma: get!(SyncGainGamma),
+            sync_gain_smooth: get!(SyncGainSmooth),
+            sync_gain_motivity: get!(SyncGainMotivity),
+            sync_gain_speed: get!(SyncGainSpeed),
             angle_rotation: get!(AngleRotation),
         }
     }

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -191,6 +191,7 @@ declare_params!(
         Smooth,
         Motivity,
         SyncSpeed,
+        Gain,
     },
     NoAccel {},
 );
@@ -232,6 +233,7 @@ impl Param {
             Param::Smooth => "SMOOTH",
             Param::Motivity => "MOTIVITY",
             Param::SyncSpeed => "SYNC_SPEED",
+            Param::Gain => "GAIN",
             Param::AngleRotation => "ANGLE_ROTATION",
         }
     }
@@ -251,6 +253,7 @@ impl Param {
             Param::Smooth => "Smooth",
             Param::Motivity => "Motivity",
             Param::SyncSpeed => "Sync Speed",
+            Param::Gain => "Gain",
             Param::AngleRotation => "Angle Rotation",
         }
     }
@@ -275,6 +278,7 @@ impl Param {
             Param::Smooth => "Smoothing factor (0-1). Higher = more gradual transitions.",
             Param::Motivity => "Degree of acceleration effect. Must be > 1.",
             Param::SyncSpeed => "Synchronization speed. Controls how fast sync responds.",
+            Param::Gain => "Interpret the Synchronous curve as gain (0 or 1).",
         }
     }
 }
@@ -304,6 +308,16 @@ fn format_param_value_works() {
     assert_eq!(format_param_value(100.0), "100");
     assert_eq!(format_param_value(0.0600), "0.06");
     assert_eq!(format_param_value(0.055000), "0.055");
+}
+
+#[cfg(test)]
+#[test]
+fn gain_is_a_binary_switch() {
+    assert!(validate_param_value(Param::Gain, 0.0).is_ok());
+    assert!(validate_param_value(Param::Gain, 1.0).is_ok());
+    assert!(validate_param_value(Param::Gain, -1.0).is_err());
+    assert!(validate_param_value(Param::Gain, 0.5).is_err());
+    assert!(validate_param_value(Param::Gain, 2.0).is_err());
 }
 
 pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Result<()> {
@@ -351,6 +365,11 @@ pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Resu
         Param::SyncSpeed => {
             if value <= 0.0 {
                 anyhow::bail!("'Synchronous speed' must be positive");
+            }
+        }
+        Param::Gain => {
+            if value != 0.0 && value != 1.0 {
+                anyhow::bail!("Gain must be either 0 or 1");
             }
         }
     }

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -191,10 +191,17 @@ declare_params!(
         Smooth,
         Motivity,
         SyncSpeed,
-        Gain,
     },
     NoAccel {},
+    SynchronousGain {
+        SyncGainGamma,
+        SyncGainSmooth,
+        SyncGainMotivity,
+        SyncGainSpeed,
+    },
 );
+
+pub const ALL_SYNCHRONOUS_GAIN_PARAMS: &[Param] = ALL_SYNCHRONOUSGAIN_PARAMS;
 
 impl AccelMode {
     pub fn as_title(&self) -> &'static str {
@@ -203,6 +210,7 @@ impl AccelMode {
             AccelMode::Natural => "Natural (w/ Gain)",
             AccelMode::Synchronous => "Synchronous",
             AccelMode::NoAccel => "No Acceleration",
+            AccelMode::SynchronousGain => "Synchronous (Gain)",
         }
     }
 }
@@ -233,7 +241,10 @@ impl Param {
             Param::Smooth => "SMOOTH",
             Param::Motivity => "MOTIVITY",
             Param::SyncSpeed => "SYNC_SPEED",
-            Param::Gain => "GAIN",
+            Param::SyncGainGamma => "SYNC_GAIN_GAMMA",
+            Param::SyncGainSmooth => "SYNC_GAIN_SMOOTH",
+            Param::SyncGainMotivity => "SYNC_GAIN_MOTIVITY",
+            Param::SyncGainSpeed => "SYNC_GAIN_SPEED",
             Param::AngleRotation => "ANGLE_ROTATION",
         }
     }
@@ -253,7 +264,10 @@ impl Param {
             Param::Smooth => "Smooth",
             Param::Motivity => "Motivity",
             Param::SyncSpeed => "Sync Speed",
-            Param::Gain => "Gain",
+            Param::SyncGainGamma => "Gamma",
+            Param::SyncGainSmooth => "Smooth",
+            Param::SyncGainMotivity => "Motivity",
+            Param::SyncGainSpeed => "Sync Speed",
             Param::AngleRotation => "Angle Rotation",
         }
     }
@@ -278,7 +292,10 @@ impl Param {
             Param::Smooth => "Smoothing factor (0-1). Higher = more gradual transitions.",
             Param::Motivity => "Degree of acceleration effect. Must be > 1.",
             Param::SyncSpeed => "Synchronization speed. Controls how fast sync responds.",
-            Param::Gain => "Interpret the Synchronous curve as gain (0 or 1).",
+            Param::SyncGainGamma => "Exponent controlling the gain curve shape.",
+            Param::SyncGainSmooth => "Gain curve smoothing factor (0-1).",
+            Param::SyncGainMotivity => "Degree of gain acceleration effect. Must be > 1.",
+            Param::SyncGainSpeed => "Synchronization speed for the gain curve.",
         }
     }
 }
@@ -312,12 +329,13 @@ fn format_param_value_works() {
 
 #[cfg(test)]
 #[test]
-fn gain_is_a_binary_switch() {
-    assert!(validate_param_value(Param::Gain, 0.0).is_ok());
-    assert!(validate_param_value(Param::Gain, 1.0).is_ok());
-    assert!(validate_param_value(Param::Gain, -1.0).is_err());
-    assert!(validate_param_value(Param::Gain, 0.5).is_err());
-    assert!(validate_param_value(Param::Gain, 2.0).is_err());
+fn synchronous_gain_has_stable_mode_and_parameter_names() {
+    assert_eq!(AccelMode::NoAccel.ordinal(), 3);
+    assert_eq!(AccelMode::SynchronousGain.ordinal(), 4);
+    assert_eq!(Param::SyncGainGamma.name(), "SYNC_GAIN_GAMMA");
+    assert_eq!(Param::SyncGainSmooth.name(), "SYNC_GAIN_SMOOTH");
+    assert_eq!(Param::SyncGainMotivity.name(), "SYNC_GAIN_MOTIVITY");
+    assert_eq!(Param::SyncGainSpeed.name(), "SYNC_GAIN_SPEED");
 }
 
 pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Result<()> {
@@ -347,29 +365,24 @@ pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Resu
                 anyhow::bail!("limit cannot be less than 1");
             }
         }
-        Param::Gamma => {
+        Param::Gamma | Param::SyncGainGamma => {
             if value <= 0.0 {
                 anyhow::bail!("Gamma must be positive");
             }
         }
-        Param::Smooth => {
+        Param::Smooth | Param::SyncGainSmooth => {
             if !(0.0..=1.0).contains(&value) {
                 anyhow::bail!("Smooth must be between 0 and 1");
             }
         }
-        Param::Motivity => {
+        Param::Motivity | Param::SyncGainMotivity => {
             if value <= 1.0 {
                 anyhow::bail!("Motivity must be greater than 1");
             }
         }
-        Param::SyncSpeed => {
+        Param::SyncSpeed | Param::SyncGainSpeed => {
             if value <= 0.0 {
                 anyhow::bail!("'Synchronous speed' must be positive");
-            }
-        }
-        Param::Gain => {
-            if value != 0.0 && value != 1.0 {
-                anyhow::bail!("Gain must be either 0 or 1");
             }
         }
     }

--- a/crates/core/src/persist.rs
+++ b/crates/core/src/persist.rs
@@ -11,7 +11,7 @@ use crate::{
     fixedptc::Fpt,
     params::{
         ALL_MODES, AccelMode, CommonParamArgs, LinearParamArgs, NaturalParamArgs, Param,
-        SynchronousParamArgs, format_param_value, validate_param_value,
+        SynchronousGainParamArgs, SynchronousParamArgs, format_param_value, validate_param_value,
     },
 };
 
@@ -122,14 +122,31 @@ impl SysFsStore {
             smooth,
             motivity,
             sync_speed,
-            gain,
         } = args;
 
         self.set(Param::Gamma, gamma)?;
         self.set(Param::Smooth, smooth)?;
         self.set(Param::Motivity, motivity)?;
         self.set(Param::SyncSpeed, sync_speed)?;
-        self.set(Param::Gain, gain)?;
+
+        Ok(())
+    }
+
+    pub fn set_all_synchronous_gain(
+        &mut self,
+        args: SynchronousGainParamArgs,
+    ) -> anyhow::Result<()> {
+        let SynchronousGainParamArgs {
+            sync_gain_gamma,
+            sync_gain_smooth,
+            sync_gain_motivity,
+            sync_gain_speed,
+        } = args;
+
+        self.set(Param::SyncGainGamma, sync_gain_gamma)?;
+        self.set(Param::SyncGainSmooth, sync_gain_smooth)?;
+        self.set(Param::SyncGainMotivity, sync_gain_motivity)?;
+        self.set(Param::SyncGainSpeed, sync_gain_speed)?;
 
         Ok(())
     }

--- a/crates/core/src/persist.rs
+++ b/crates/core/src/persist.rs
@@ -122,12 +122,14 @@ impl SysFsStore {
             smooth,
             motivity,
             sync_speed,
+            gain,
         } = args;
 
         self.set(Param::Gamma, gamma)?;
         self.set(Param::Smooth, smooth)?;
         self.set(Param::Motivity, motivity)?;
         self.set(Param::SyncSpeed, sync_speed)?;
+        self.set(Param::Gain, gain)?;
 
         Ok(())
     }

--- a/crates/core/src/sens_fns.rs
+++ b/crates/core/src/sens_fns.rs
@@ -1,5 +1,6 @@
 use crate::{
     AccelParams, AccelParamsByMode, LinearCurveParams, NaturalCurveParams, SynchronousCurveParams,
+    SynchronousGainCurveParams,
     libmaccel::{self, fixedptc::Fpt},
     params::AllParamArgs,
 };
@@ -24,10 +25,17 @@ impl AllParamArgs {
                 smooth: self.smooth,
                 motivity: self.motivity,
                 sync_speed: self.sync_speed,
-                gain: self.gain,
             }),
             AccelMode::NoAccel => {
                 AccelParamsByMode::NoAccel(crate::params::NoAccelCurveParams { _ffi_guard: [] })
+            }
+            AccelMode::SynchronousGain => {
+                AccelParamsByMode::SynchronousGain(SynchronousGainCurveParams {
+                    sync_gain_gamma: self.sync_gain_gamma,
+                    sync_gain_smooth: self.sync_gain_smooth,
+                    sync_gain_motivity: self.sync_gain_motivity,
+                    sync_gain_speed: self.sync_gain_speed,
+                })
             }
         };
 

--- a/crates/core/src/sens_fns.rs
+++ b/crates/core/src/sens_fns.rs
@@ -24,6 +24,7 @@ impl AllParamArgs {
                 smooth: self.smooth,
                 motivity: self.motivity,
                 sync_speed: self.sync_speed,
+                gain: self.gain,
             }),
             AccelMode::NoAccel => {
                 AccelParamsByMode::NoAccel(crate::params::NoAccelCurveParams { _ffi_guard: [] })

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -10,6 +10,50 @@
 #include "math.h"
 #include "speed.h"
 
+#ifdef __KERNEL__
+#include <linux/spinlock.h>
+
+static DEFINE_RWLOCK(synchronous_gain_lut_lock);
+static struct synchronous_gain_lut synchronous_gain_lut;
+
+static inline void
+publish_synchronous_gain_lut(const struct synchronous_gain_lut *lut) {
+  write_lock(&synchronous_gain_lut_lock);
+  synchronous_gain_lut = *lut;
+  write_unlock(&synchronous_gain_lut_lock);
+}
+
+static inline fpt
+synchronous_gain_sensitivity(fpt input_speed,
+                             struct synchronous_curve_args args) {
+  fpt sens;
+
+  read_lock(&synchronous_gain_lut_lock);
+  sens = __synchronous_gain_lut_lookup(input_speed, &synchronous_gain_lut);
+  read_unlock(&synchronous_gain_lut_lock);
+  return sens;
+}
+#else
+static inline fpt
+synchronous_gain_sensitivity(fpt input_speed,
+                             struct synchronous_curve_args args) {
+  static _Thread_local struct synchronous_gain_lut lut;
+  static _Thread_local struct synchronous_curve_args cached_args;
+  static _Thread_local int initialized;
+
+  if (!initialized || args.gamma != cached_args.gamma ||
+      args.smooth != cached_args.smooth ||
+      args.motivity != cached_args.motivity ||
+      args.sync_speed != cached_args.sync_speed) {
+    __synchronous_gain_lut_init(&lut, args);
+    cached_args = args;
+    initialized = 1;
+  }
+
+  return __synchronous_gain_lut_lookup(input_speed, &lut);
+}
+#endif
+
 struct no_accel_curve_args {};
 
 union __accel_args {
@@ -43,7 +87,10 @@ static inline struct vector sensitivity(fpt input_speed,
   switch (args.tag) {
   case synchronous:
     dbg("accel mode %d: synchronous", args.tag);
-    sens = __synchronous_sens_fun(input_speed, args.args.synchronous);
+    sens =
+        args.args.synchronous.gain
+            ? synchronous_gain_sensitivity(input_speed, args.args.synchronous)
+            : __synchronous_sens_fun(input_speed, args.args.synchronous);
     break;
   case natural:
     dbg("accel mode %d: natural", args.tag);

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -5,61 +5,11 @@
 #include "accel/mode.h"
 #include "accel/natural.h"
 #include "accel/synchronous.h"
+#include "accel/synchronous_gain.h"
 #include "dbg.h"
 #include "fixedptc.h"
 #include "math.h"
 #include "speed.h"
-
-#ifdef __KERNEL__
-#include <linux/mutex.h>
-#include <linux/spinlock.h>
-
-static DEFINE_RWLOCK(synchronous_gain_lut_lock);
-static DEFINE_MUTEX(synchronous_gain_lut_update_lock);
-static struct synchronous_gain_lut synchronous_gain_lut;
-
-static inline void
-update_synchronous_gain_lut(struct synchronous_curve_args args) {
-  static struct synchronous_gain_lut next_lut;
-
-  mutex_lock(&synchronous_gain_lut_update_lock);
-  __synchronous_gain_lut_init(&next_lut, args);
-  write_lock(&synchronous_gain_lut_lock);
-  synchronous_gain_lut = next_lut;
-  write_unlock(&synchronous_gain_lut_lock);
-  mutex_unlock(&synchronous_gain_lut_update_lock);
-}
-
-static inline fpt
-synchronous_gain_sensitivity(fpt input_speed,
-                             struct synchronous_curve_args args) {
-  fpt sens;
-
-  read_lock(&synchronous_gain_lut_lock);
-  sens = __synchronous_gain_lut_lookup(input_speed, &synchronous_gain_lut);
-  read_unlock(&synchronous_gain_lut_lock);
-  return sens;
-}
-#else
-static inline fpt
-synchronous_gain_sensitivity(fpt input_speed,
-                             struct synchronous_curve_args args) {
-  static _Thread_local struct synchronous_gain_lut lut;
-  static _Thread_local struct synchronous_curve_args cached_args;
-  static _Thread_local int initialized;
-
-  if (!initialized || args.gamma != cached_args.gamma ||
-      args.smooth != cached_args.smooth ||
-      args.motivity != cached_args.motivity ||
-      args.sync_speed != cached_args.sync_speed) {
-    __synchronous_gain_lut_init(&lut, args);
-    cached_args = args;
-    initialized = 1;
-  }
-
-  return __synchronous_gain_lut_lookup(input_speed, &lut);
-}
-#endif
 
 struct no_accel_curve_args {};
 
@@ -67,7 +17,7 @@ union __accel_args {
   struct natural_curve_args natural;
   struct linear_curve_args linear;
   struct synchronous_curve_args synchronous;
-  struct synchronous_curve_args synchronous_gain;
+  struct synchronous_gain_curve_args synchronous_gain;
   struct no_accel_curve_args no_accel;
 };
 

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -11,16 +11,23 @@
 #include "speed.h"
 
 #ifdef __KERNEL__
+#include <linux/mutex.h>
 #include <linux/spinlock.h>
 
 static DEFINE_RWLOCK(synchronous_gain_lut_lock);
+static DEFINE_MUTEX(synchronous_gain_lut_update_lock);
 static struct synchronous_gain_lut synchronous_gain_lut;
 
 static inline void
-publish_synchronous_gain_lut(const struct synchronous_gain_lut *lut) {
+update_synchronous_gain_lut(struct synchronous_curve_args args) {
+  static struct synchronous_gain_lut next_lut;
+
+  mutex_lock(&synchronous_gain_lut_update_lock);
+  __synchronous_gain_lut_init(&next_lut, args);
   write_lock(&synchronous_gain_lut_lock);
-  synchronous_gain_lut = *lut;
+  synchronous_gain_lut = next_lut;
   write_unlock(&synchronous_gain_lut_lock);
+  mutex_unlock(&synchronous_gain_lut_update_lock);
 }
 
 static inline fpt

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -67,6 +67,7 @@ union __accel_args {
   struct natural_curve_args natural;
   struct linear_curve_args linear;
   struct synchronous_curve_args synchronous;
+  struct synchronous_curve_args synchronous_gain;
   struct no_accel_curve_args no_accel;
 };
 
@@ -92,12 +93,14 @@ static inline struct vector sensitivity(fpt input_speed,
   fpt sens;
 
   switch (args.tag) {
+  case synchronous_gain:
+    dbg("accel mode %d: synchronous_gain", args.tag);
+    sens =
+        synchronous_gain_sensitivity(input_speed, args.args.synchronous_gain);
+    break;
   case synchronous:
     dbg("accel mode %d: synchronous", args.tag);
-    sens =
-        args.args.synchronous.gain
-            ? synchronous_gain_sensitivity(input_speed, args.args.synchronous)
-            : __synchronous_sens_fun(input_speed, args.args.synchronous);
+    sens = __synchronous_sens_fun(input_speed, args.args.synchronous);
     break;
   case natural:
     dbg("accel mode %d: natural", args.tag);

--- a/driver/accel/mode.h
+++ b/driver/accel/mode.h
@@ -1,6 +1,12 @@
 #ifndef __ACCEL_MODE_H
 #define __ACCEL_MODE_H
 
-enum accel_mode : unsigned char { linear, natural, synchronous, no_accel };
+enum accel_mode : unsigned char {
+  linear,
+  natural,
+  synchronous,
+  no_accel,
+  synchronous_gain
+};
 
 #endif // !__ACCEL_MODE_H

--- a/driver/accel/synchronous.h
+++ b/driver/accel/synchronous.h
@@ -3,23 +3,11 @@
 
 #include "../fixedptc.h"
 
-#define SYNCHRONOUS_GAIN_LUT_START -3
-#define SYNCHRONOUS_GAIN_LUT_STOP 9
-#define SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE 8
-#define SYNCHRONOUS_GAIN_LUT_SIZE                                              \
-  ((SYNCHRONOUS_GAIN_LUT_STOP - SYNCHRONOUS_GAIN_LUT_START) *                  \
-       SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE +                                \
-   1)
-
 struct synchronous_curve_args {
   fpt gamma;
   fpt smooth;
   fpt motivity;
   fpt sync_speed;
-};
-
-struct synchronous_gain_lut {
-  fpt velocity[SYNCHRONOUS_GAIN_LUT_SIZE];
 };
 
 static inline fpt __synchronous_ln(fpt value) {
@@ -100,78 +88,5 @@ static inline fpt __synchronous_sens_fun(fpt input_speed,
                             sharpness_recip);
     return fpt_exp(fpt_mul(exponent, log_motivity));
   }
-}
-
-static inline fpt __synchronous_gain_pow2(int exponent) {
-  if (exponent >= 0)
-    return fpt_fromint(1 << exponent);
-
-  return FIXEDPT_ONE >> -exponent;
-}
-
-static inline fpt __synchronous_gain_x(int index) {
-  int octave = index / SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE;
-  int step = index % SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE;
-  fpt octave_start =
-      __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_START + octave);
-
-  return fpt_mul(fpt_fromint(step + SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE),
-                 fpt_div(octave_start,
-                         fpt_fromint(SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE)));
-}
-
-static inline void
-__synchronous_gain_lut_init(struct synchronous_gain_lut *lut,
-                            struct synchronous_curve_args args) {
-  fpt sum = 0;
-  fpt previous_x = 0;
-  int i;
-
-  for (i = 0; i < SYNCHRONOUS_GAIN_LUT_SIZE; i++) {
-    fpt x = __synchronous_gain_x(i);
-    fpt interval = fpt_div(x - previous_x, fpt_fromint(2));
-
-    sum +=
-        fpt_mul(__synchronous_sens_fun(previous_x + interval, args), interval);
-    sum += fpt_mul(__synchronous_sens_fun(x, args), interval);
-    lut->velocity[i] = sum;
-    previous_x = x;
-  }
-}
-
-static inline fpt __synchronous_gain_lerp(fpt a, fpt b, fpt t) {
-  return a + fpt_mul(t, b - a);
-}
-
-static inline fpt
-__synchronous_gain_lut_lookup(fpt input_speed,
-                              const struct synchronous_gain_lut *lut) {
-  const fpt x_start = __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_START);
-  int exponent = SYNCHRONOUS_GAIN_LUT_START;
-  fpt base;
-  fpt index_f;
-  int index;
-  fpt velocity;
-
-  if (input_speed <= x_start)
-    return fpt_div(lut->velocity[0], x_start);
-
-  while (exponent < SYNCHRONOUS_GAIN_LUT_STOP - 1 &&
-         input_speed >= __synchronous_gain_pow2(exponent + 1))
-    exponent++;
-
-  base = __synchronous_gain_pow2(exponent);
-  index_f = fpt_fromint((exponent - SYNCHRONOUS_GAIN_LUT_START) *
-                        SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE) +
-            fpt_mul(fpt_div(input_speed - base, base),
-                    fpt_fromint(SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE));
-  index = fpt_toint(index_f);
-  if (index > SYNCHRONOUS_GAIN_LUT_SIZE - 2)
-    index = SYNCHRONOUS_GAIN_LUT_SIZE - 2;
-
-  velocity =
-      __synchronous_gain_lerp(lut->velocity[index], lut->velocity[index + 1],
-                              index_f - fpt_fromint(index));
-  return fpt_div(velocity, input_speed);
 }
 #endif

--- a/driver/accel/synchronous.h
+++ b/driver/accel/synchronous.h
@@ -16,7 +16,6 @@ struct synchronous_curve_args {
   fpt smooth;
   fpt motivity;
   fpt sync_speed;
-  fpt gain;
 };
 
 struct synchronous_gain_lut {

--- a/driver/accel/synchronous.h
+++ b/driver/accel/synchronous.h
@@ -129,17 +129,12 @@ __synchronous_gain_lut_init(struct synchronous_gain_lut *lut,
   int i;
 
   for (i = 0; i < SYNCHRONOUS_GAIN_LUT_SIZE; i++) {
-    fpt x = i == SYNCHRONOUS_GAIN_LUT_SIZE - 1
-                ? __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_STOP)
-                : __synchronous_gain_x(i);
+    fpt x = __synchronous_gain_x(i);
     fpt interval = fpt_div(x - previous_x, fpt_fromint(2));
-    int partition;
 
-    for (partition = 1; partition <= 2; partition++) {
-      fpt sample_x = previous_x + fpt_mul(fpt_fromint(partition), interval);
-      sum += fpt_mul(__synchronous_sens_fun(sample_x, args), interval);
-    }
-
+    sum +=
+        fpt_mul(__synchronous_sens_fun(previous_x + interval, args), interval);
+    sum += fpt_mul(__synchronous_sens_fun(x, args), interval);
     lut->velocity[i] = sum;
     previous_x = x;
   }

--- a/driver/accel/synchronous.h
+++ b/driver/accel/synchronous.h
@@ -3,21 +3,61 @@
 
 #include "../fixedptc.h"
 
+#define SYNCHRONOUS_GAIN_LUT_START -3
+#define SYNCHRONOUS_GAIN_LUT_STOP 9
+#define SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE 8
+#define SYNCHRONOUS_GAIN_LUT_SIZE                                              \
+  ((SYNCHRONOUS_GAIN_LUT_STOP - SYNCHRONOUS_GAIN_LUT_START) *                  \
+       SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE +                                \
+   1)
+
 struct synchronous_curve_args {
   fpt gamma;
   fpt smooth;
   fpt motivity;
   fpt sync_speed;
+  fpt gain;
 };
+
+struct synchronous_gain_lut {
+  fpt velocity[SYNCHRONOUS_GAIN_LUT_SIZE];
+};
+
+static inline fpt __synchronous_ln(fpt value) {
+  const fpt ln_two = fpt_rconst(0.69314718055994530942);
+  int exponent = 0;
+
+  if (value <= 0)
+    return fpt_ln(value);
+  while (value < FIXEDPT_ONE) {
+    value <<= 1;
+    exponent--;
+  }
+  return fpt_ln(value) + fpt_mul(fpt_fromint(exponent), ln_two);
+}
+
+static inline fpt __synchronous_tanh(fpt value) {
+#if FIXEDPT_BITS == 64
+  const fpt saturation = fpt_fromint(10);
+#else
+  const fpt saturation = fpt_fromint(5);
+#endif
+
+  if (value >= saturation)
+    return FIXEDPT_ONE;
+  if (value <= -saturation)
+    return -FIXEDPT_ONE;
+  return fpt_tanh(value);
+}
 
 /**
  * Sensitivity Function for `Synchronous` Acceleration
  */
 static inline fpt __synchronous_sens_fun(fpt input_speed,
                                          struct synchronous_curve_args args) {
-  fpt log_motivity = fpt_ln(args.motivity);
+  fpt log_motivity = __synchronous_ln(args.motivity);
   fpt gamma_const = fpt_div(args.gamma, log_motivity);
-  fpt log_syncspeed = fpt_ln(args.sync_speed);
+  fpt log_syncspeed = __synchronous_ln(args.sync_speed);
   fpt syncspeed = args.sync_speed;
   fpt sharpness = args.smooth == 0 ? fpt_rconst(16.0)
                                    : fpt_div(fpt_rconst(0.5), args.smooth);
@@ -29,7 +69,8 @@ static inline fpt __synchronous_sens_fun(fpt input_speed,
   // if sharpness >= 16, use linear clamp for activation function.
   // linear clamp means: fpt_clamp(input_speed, -1, 1).
   if (use_linear_clamp) {
-    fpt log_space = fpt_mul(gamma_const, (fpt_ln(input_speed) - log_syncspeed));
+    fpt log_space =
+        fpt_mul(gamma_const, (__synchronous_ln(input_speed) - log_syncspeed));
 
     if (log_space < -FIXEDPT_ONE) {
       return minimum_sens;
@@ -46,19 +87,97 @@ static inline fpt __synchronous_sens_fun(fpt input_speed,
     return FIXEDPT_ONE;
   }
 
-  fpt log_x = fpt_ln(input_speed);
+  fpt log_x = __synchronous_ln(input_speed);
   fpt log_diff = log_x - log_syncspeed;
 
   if (log_diff > 0) {
     fpt log_space = fpt_mul(gamma_const, log_diff);
-    fpt exponent =
-        fpt_pow(fpt_tanh(fpt_pow(log_space, sharpness)), sharpness_recip);
+    fpt exponent = fpt_pow(__synchronous_tanh(fpt_pow(log_space, sharpness)),
+                           sharpness_recip);
     return fpt_exp(fpt_mul(exponent, log_motivity));
   } else {
     fpt log_space = fpt_mul(-gamma_const, log_diff);
-    fpt exponent =
-        -fpt_pow(fpt_tanh(fpt_pow(log_space, sharpness)), sharpness_recip);
+    fpt exponent = -fpt_pow(__synchronous_tanh(fpt_pow(log_space, sharpness)),
+                            sharpness_recip);
     return fpt_exp(fpt_mul(exponent, log_motivity));
   }
+}
+
+static inline fpt __synchronous_gain_pow2(int exponent) {
+  if (exponent >= 0)
+    return fpt_fromint(1 << exponent);
+
+  return FIXEDPT_ONE >> -exponent;
+}
+
+static inline fpt __synchronous_gain_x(int index) {
+  int octave = index / SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE;
+  int step = index % SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE;
+  fpt octave_start =
+      __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_START + octave);
+
+  return fpt_mul(fpt_fromint(step + SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE),
+                 fpt_div(octave_start,
+                         fpt_fromint(SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE)));
+}
+
+static inline void
+__synchronous_gain_lut_init(struct synchronous_gain_lut *lut,
+                            struct synchronous_curve_args args) {
+  fpt sum = 0;
+  fpt previous_x = 0;
+  int i;
+
+  for (i = 0; i < SYNCHRONOUS_GAIN_LUT_SIZE; i++) {
+    fpt x = i == SYNCHRONOUS_GAIN_LUT_SIZE - 1
+                ? __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_STOP)
+                : __synchronous_gain_x(i);
+    fpt interval = fpt_div(x - previous_x, fpt_fromint(2));
+    int partition;
+
+    for (partition = 1; partition <= 2; partition++) {
+      fpt sample_x = previous_x + fpt_mul(fpt_fromint(partition), interval);
+      sum += fpt_mul(__synchronous_sens_fun(sample_x, args), interval);
+    }
+
+    lut->velocity[i] = sum;
+    previous_x = x;
+  }
+}
+
+static inline fpt __synchronous_gain_lerp(fpt a, fpt b, fpt t) {
+  return a + fpt_mul(t, b - a);
+}
+
+static inline fpt
+__synchronous_gain_lut_lookup(fpt input_speed,
+                              const struct synchronous_gain_lut *lut) {
+  const fpt x_start = __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_START);
+  int exponent = SYNCHRONOUS_GAIN_LUT_START;
+  fpt base;
+  fpt index_f;
+  int index;
+  fpt velocity;
+
+  if (input_speed <= x_start)
+    return fpt_div(lut->velocity[0], x_start);
+
+  while (exponent < SYNCHRONOUS_GAIN_LUT_STOP - 1 &&
+         input_speed >= __synchronous_gain_pow2(exponent + 1))
+    exponent++;
+
+  base = __synchronous_gain_pow2(exponent);
+  index_f = fpt_fromint((exponent - SYNCHRONOUS_GAIN_LUT_START) *
+                        SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE) +
+            fpt_mul(fpt_div(input_speed - base, base),
+                    fpt_fromint(SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE));
+  index = fpt_toint(index_f);
+  if (index > SYNCHRONOUS_GAIN_LUT_SIZE - 2)
+    index = SYNCHRONOUS_GAIN_LUT_SIZE - 2;
+
+  velocity =
+      __synchronous_gain_lerp(lut->velocity[index], lut->velocity[index + 1],
+                              index_f - fpt_fromint(index));
+  return fpt_div(velocity, input_speed);
 }
 #endif

--- a/driver/accel/synchronous_gain.h
+++ b/driver/accel/synchronous_gain.h
@@ -1,0 +1,215 @@
+#ifndef __ACCEL_SYNCHRONOUS_GAIN_H_
+#define __ACCEL_SYNCHRONOUS_GAIN_H_
+
+#include "../fixedptc.h"
+
+#define SYNCHRONOUS_GAIN_LUT_START -3
+#define SYNCHRONOUS_GAIN_LUT_STOP 9
+#define SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE 8
+#define SYNCHRONOUS_GAIN_LUT_SIZE                                              \
+  ((SYNCHRONOUS_GAIN_LUT_STOP - SYNCHRONOUS_GAIN_LUT_START) *                  \
+       SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE +                                \
+   1)
+
+struct synchronous_gain_curve_args {
+  fpt gamma;
+  fpt smooth;
+  fpt motivity;
+  fpt sync_speed;
+};
+
+struct synchronous_gain_lut {
+  fpt velocity[SYNCHRONOUS_GAIN_LUT_SIZE];
+};
+
+static inline fpt __synchronous_gain_ln(fpt value) {
+  const fpt ln_two = fpt_rconst(0.69314718055994530942);
+  int exponent = 0;
+
+  if (value <= 0)
+    return fpt_ln(value);
+  while (value < FIXEDPT_ONE) {
+    value <<= 1;
+    exponent--;
+  }
+  return fpt_ln(value) + fpt_mul(fpt_fromint(exponent), ln_two);
+}
+
+static inline fpt __synchronous_gain_tanh(fpt value) {
+#if FIXEDPT_BITS == 64
+  const fpt saturation = fpt_fromint(10);
+#else
+  const fpt saturation = fpt_fromint(5);
+#endif
+
+  if (value >= saturation)
+    return FIXEDPT_ONE;
+  if (value <= -saturation)
+    return -FIXEDPT_ONE;
+  return fpt_tanh(value);
+}
+
+static inline fpt
+__synchronous_gain_activation(fpt input_speed,
+                              struct synchronous_gain_curve_args args) {
+  fpt log_motivity = __synchronous_gain_ln(args.motivity);
+  fpt gamma_const = fpt_div(args.gamma, log_motivity);
+  fpt log_syncspeed = __synchronous_gain_ln(args.sync_speed);
+  fpt sharpness = args.smooth == 0 ? fpt_rconst(16.0)
+                                   : fpt_div(fpt_rconst(0.5), args.smooth);
+  int use_linear_clamp = sharpness >= fpt_rconst(16.0);
+  fpt sharpness_recip = fpt_div(FIXEDPT_ONE, sharpness);
+
+  if (use_linear_clamp) {
+    fpt log_space = fpt_mul(
+        gamma_const, (__synchronous_gain_ln(input_speed) - log_syncspeed));
+
+    if (log_space < -FIXEDPT_ONE)
+      return fpt_div(FIXEDPT_ONE, args.motivity);
+    if (log_space > FIXEDPT_ONE)
+      return args.motivity;
+    return fpt_exp(fpt_mul(log_space, log_motivity));
+  }
+
+  if (input_speed == args.sync_speed)
+    return FIXEDPT_ONE;
+
+  {
+    fpt log_diff = __synchronous_gain_ln(input_speed) - log_syncspeed;
+
+    if (log_diff > 0) {
+      fpt log_space = fpt_mul(gamma_const, log_diff);
+      fpt exponent =
+          fpt_pow(__synchronous_gain_tanh(fpt_pow(log_space, sharpness)),
+                  sharpness_recip);
+      return fpt_exp(fpt_mul(exponent, log_motivity));
+    } else {
+      fpt log_space = fpt_mul(-gamma_const, log_diff);
+      fpt exponent =
+          -fpt_pow(__synchronous_gain_tanh(fpt_pow(log_space, sharpness)),
+                   sharpness_recip);
+      return fpt_exp(fpt_mul(exponent, log_motivity));
+    }
+  }
+}
+
+static inline fpt __synchronous_gain_pow2(int exponent) {
+  if (exponent >= 0)
+    return fpt_fromint(1 << exponent);
+  return FIXEDPT_ONE >> -exponent;
+}
+
+static inline fpt __synchronous_gain_x(int index) {
+  int octave = index / SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE;
+  int step = index % SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE;
+  fpt octave_start =
+      __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_START + octave);
+
+  return fpt_mul(fpt_fromint(step + SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE),
+                 fpt_div(octave_start,
+                         fpt_fromint(SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE)));
+}
+
+static inline void
+__synchronous_gain_lut_init(struct synchronous_gain_lut *lut,
+                            struct synchronous_gain_curve_args args) {
+  fpt sum = 0;
+  fpt previous_x = 0;
+  int i;
+
+  for (i = 0; i < SYNCHRONOUS_GAIN_LUT_SIZE; i++) {
+    fpt x = __synchronous_gain_x(i);
+    fpt interval = fpt_div(x - previous_x, fpt_fromint(2));
+
+    sum += fpt_mul(__synchronous_gain_activation(previous_x + interval, args),
+                   interval);
+    sum += fpt_mul(__synchronous_gain_activation(x, args), interval);
+    lut->velocity[i] = sum;
+    previous_x = x;
+  }
+}
+
+static inline fpt
+__synchronous_gain_lut_lookup(fpt input_speed,
+                              const struct synchronous_gain_lut *lut) {
+  const fpt x_start = __synchronous_gain_pow2(SYNCHRONOUS_GAIN_LUT_START);
+  int exponent = SYNCHRONOUS_GAIN_LUT_START;
+  fpt base;
+  fpt index_f;
+  int index;
+  fpt velocity;
+
+  if (input_speed <= x_start)
+    return fpt_div(lut->velocity[0], x_start);
+
+  while (exponent < SYNCHRONOUS_GAIN_LUT_STOP - 1 &&
+         input_speed >= __synchronous_gain_pow2(exponent + 1))
+    exponent++;
+
+  base = __synchronous_gain_pow2(exponent);
+  index_f = fpt_fromint((exponent - SYNCHRONOUS_GAIN_LUT_START) *
+                        SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE) +
+            fpt_mul(fpt_div(input_speed - base, base),
+                    fpt_fromint(SYNCHRONOUS_GAIN_LUT_POINTS_PER_OCTAVE));
+  index = fpt_toint(index_f);
+  if (index > SYNCHRONOUS_GAIN_LUT_SIZE - 2)
+    index = SYNCHRONOUS_GAIN_LUT_SIZE - 2;
+
+  velocity = lut->velocity[index] +
+             fpt_mul(index_f - fpt_fromint(index),
+                     lut->velocity[index + 1] - lut->velocity[index]);
+  return fpt_div(velocity, input_speed);
+}
+
+#ifdef __KERNEL__
+#include <linux/mutex.h>
+#include <linux/spinlock.h>
+
+static DEFINE_RWLOCK(synchronous_gain_lut_lock);
+static DEFINE_MUTEX(synchronous_gain_lut_update_lock);
+static struct synchronous_gain_lut synchronous_gain_lut;
+
+static inline void
+update_synchronous_gain_lut(struct synchronous_gain_curve_args args) {
+  static struct synchronous_gain_lut next_lut;
+
+  mutex_lock(&synchronous_gain_lut_update_lock);
+  __synchronous_gain_lut_init(&next_lut, args);
+  write_lock(&synchronous_gain_lut_lock);
+  synchronous_gain_lut = next_lut;
+  write_unlock(&synchronous_gain_lut_lock);
+  mutex_unlock(&synchronous_gain_lut_update_lock);
+}
+
+static inline fpt
+synchronous_gain_sensitivity(fpt input_speed,
+                             struct synchronous_gain_curve_args args) {
+  fpt sens;
+
+  read_lock(&synchronous_gain_lut_lock);
+  sens = __synchronous_gain_lut_lookup(input_speed, &synchronous_gain_lut);
+  read_unlock(&synchronous_gain_lut_lock);
+  return sens;
+}
+#else
+static inline fpt
+synchronous_gain_sensitivity(fpt input_speed,
+                             struct synchronous_gain_curve_args args) {
+  static _Thread_local struct synchronous_gain_lut lut;
+  static _Thread_local struct synchronous_gain_curve_args cached_args;
+  static _Thread_local int initialized;
+
+  if (!initialized || args.gamma != cached_args.gamma ||
+      args.smooth != cached_args.smooth ||
+      args.motivity != cached_args.motivity ||
+      args.sync_speed != cached_args.sync_speed) {
+    __synchronous_gain_lut_init(&lut, args);
+    cached_args = args;
+    initialized = 1;
+  }
+
+  return __synchronous_gain_lut_lookup(input_speed, &lut);
+}
+#endif
+
+#endif

--- a/driver/accel_k.h
+++ b/driver/accel_k.h
@@ -21,6 +21,10 @@ static struct accel_args collect_args(void) {
   accel.angle_rotation_deg = atofp(PARAM_ANGLE_ROTATION);
 
   switch (mode) {
+  case synchronous_gain: {
+    accel.args.synchronous_gain = collect_synchronous_gain_args();
+    break;
+  }
   case synchronous: {
     accel.args.synchronous = collect_synchronous_args();
     break;

--- a/driver/accel_k.h
+++ b/driver/accel_k.h
@@ -26,6 +26,7 @@ static struct accel_args collect_args(void) {
     accel.args.synchronous.smooth = atofp(PARAM_SMOOTH);
     accel.args.synchronous.motivity = atofp(PARAM_MOTIVITY);
     accel.args.synchronous.sync_speed = atofp(PARAM_SYNC_SPEED);
+    accel.args.synchronous.gain = atofp(PARAM_GAIN);
     break;
   }
   case natural: {

--- a/driver/accel_k.h
+++ b/driver/accel_k.h
@@ -22,11 +22,7 @@ static struct accel_args collect_args(void) {
 
   switch (mode) {
   case synchronous: {
-    accel.args.synchronous.gamma = atofp(PARAM_GAMMA);
-    accel.args.synchronous.smooth = atofp(PARAM_SMOOTH);
-    accel.args.synchronous.motivity = atofp(PARAM_MOTIVITY);
-    accel.args.synchronous.sync_speed = atofp(PARAM_SYNC_SPEED);
-    accel.args.synchronous.gain = atofp(PARAM_GAIN);
+    accel.args.synchronous = collect_synchronous_args();
     break;
   }
   case natural: {

--- a/driver/fixedptc.h
+++ b/driver/fixedptc.h
@@ -148,6 +148,8 @@ static inline fpt fpt_mul(fpt A, fpt B) {
 
 #if FIXEDPT_BITS == 64
 static inline fpt div128_s64_s64(fpt dividend, fpt divisor) {
+  if (divisor == 0)
+    return 0;
   fpt high = dividend >> FIXEDPT_FBITS;
   fpt low = dividend << FIXEDPT_FBITS;
 
@@ -158,6 +160,8 @@ static inline fpt div128_s64_s64(fpt dividend, fpt divisor) {
 
 /* Divides two fpt numbers, returns the result. */
 static inline fpt fpt_div(fpt A, fpt B) {
+  if (B == 0)
+    return 0;
 #if FIXEDPT_BITS == 64
   return div128_s64_s64(A, B);
 #endif

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -7,6 +7,7 @@
  */
 static int __init driver_initialization(void) {
   int error;
+  rebuild_synchronous_gain_lut();
   error = create_char_device();
   if (error)
     return error;

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -7,7 +7,7 @@
  */
 static int __init driver_initialization(void) {
   int error;
-  rebuild_synchronous_gain_lut();
+  update_synchronous_gain_lut(collect_synchronous_args());
   error = create_char_device();
   if (error)
     return error;

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -7,7 +7,7 @@
  */
 static int __init driver_initialization(void) {
   int error;
-  update_synchronous_gain_lut(collect_synchronous_args());
+  update_synchronous_gain_lut(collect_synchronous_gain_args());
   error = create_char_device();
   if (error)
     return error;

--- a/driver/params.h
+++ b/driver/params.h
@@ -4,12 +4,21 @@
 #include "accel/mode.h"
 #include "fixedptc.h"
 #include "linux/moduleparam.h"
+#include "linux/mutex.h"
 
 #define RW_USER_GROUP 0664
 
 #define PARAM(param, default_value, desc)                                      \
   char *PARAM_##param = #default_value;                                        \
   module_param_named(param, PARAM_##param, charp, RW_USER_GROUP);              \
+  MODULE_PARM_DESC(param, desc);
+
+static const struct kernel_param_ops synchronous_param_ops;
+
+#define SYNCHRONOUS_PARAM(param, default_value, desc)                          \
+  char *PARAM_##param = #default_value;                                        \
+  module_param_cb(param, &synchronous_param_ops, &PARAM_##param,               \
+                  RW_USER_GROUP);                                              \
   MODULE_PARM_DESC(param, desc);
 
 #if FIXEDPT_BITS == 64
@@ -20,8 +29,8 @@ PARAM(YX_RATIO, 4294967296, // 1 << 32
       "A factor (Y/X) by which the final sensitivity calculated is multiplied "
       "to produce the sensitivity applied to the Y axis.");
 PARAM(INPUT_DPI, 4294967296000, // 1000 << 32
-       "The DPI of the mouse, used to normalize input to 1000 DPI equivalent "
-       "for consistent acceleration across different mice.");
+      "The DPI of the mouse, used to normalize input to 1000 DPI equivalent "
+      "for consistent acceleration across different mice.");
 #else
 PARAM(SENS_MULT, 65536, // 1 << 16
       "A factor applied the sensitivity calculation after ACCEL is applied.");
@@ -29,8 +38,8 @@ PARAM(YX_RATIO, 65536, // 1 << 16
       "A factor (Y/X) by which the final sensitivity calculated is multiplied "
       "to produce the sensitivity applied to the Y axis.");
 PARAM(INPUT_DPI, 65536000, // 1000 << 16
-       "The DPI of the mouse, used to normalize input to 1000 DPI equivalent "
-       "for consistent acceleration across different mice.");
+      "The DPI of the mouse, used to normalize input to 1000 DPI equivalent "
+      "for consistent acceleration across different mice.");
 #endif
 
 PARAM(ANGLE_ROTATION, 0,
@@ -38,7 +47,8 @@ PARAM(ANGLE_ROTATION, 0,
 // For Linear Mode
 
 PARAM(ACCEL, 0, "Control the sensitivity calculation.");
-PARAM(OFFSET, 0, "Input speed threshold (counts/ms) before acceleration begins.");
+PARAM(OFFSET, 0,
+      "Input speed threshold (counts/ms) before acceleration begins.");
 PARAM(OUTPUT_CAP, 0, "Control the maximum sensitivity.");
 
 // For Natural Mode
@@ -58,26 +68,68 @@ PARAM(LIMIT, 98304, // 1.5 << 16
 // For Synchronous Mode
 
 #if FIXEDPT_BITS == 64
-PARAM(GAMMA, 4294967296, // 1 << 32
-      "Control how fast you get from low to fast around the midpoint");
-PARAM(SMOOTH, 2147483648, // 0.5 << 32
-      "Control the suddeness of the sensitivity increase.");
-PARAM(MOTIVITY, 6442450944, // 1.5 << 32
-      "Set the maximum sensitivity while also setting the minimum to "
-      "1/MOTIVITY");
-PARAM(SYNC_SPEED, 21474836480, // 5 << 32
-      "Set The middle sensitivity between you min and max sensitivity");
+SYNCHRONOUS_PARAM(
+    GAMMA, 4294967296, // 1 << 32
+    "Control how fast you get from low to fast around the midpoint");
+SYNCHRONOUS_PARAM(SMOOTH, 2147483648, // 0.5 << 32
+                  "Control the suddeness of the sensitivity increase.");
+SYNCHRONOUS_PARAM(
+    MOTIVITY, 6442450944, // 1.5 << 32
+    "Set the maximum sensitivity while also setting the minimum to "
+    "1/MOTIVITY");
+SYNCHRONOUS_PARAM(
+    SYNC_SPEED, 21474836480, // 5 << 32
+    "Set The middle sensitivity between you min and max sensitivity");
 #else
-PARAM(GAMMA, 65536, // 1 << 16
-      "Control how fast you get from low to fast around the midpoint");
-PARAM(SMOOTH, 32768, // 0.5 << 16
-      "Control the suddeness of the sensitivity increase.");
-PARAM(MOTIVITY, 98304, // 1.5 << 16
-      "Set the maximum sensitivity while also setting the minimum to "
-      "1/MOTIVITY");
-PARAM(SYNC_SPEED, 327680, // 5 << 16
-      "Set The middle sensitivity between you min and max sensitivity");
+SYNCHRONOUS_PARAM(
+    GAMMA, 65536, // 1 << 16
+    "Control how fast you get from low to fast around the midpoint");
+SYNCHRONOUS_PARAM(SMOOTH, 32768, // 0.5 << 16
+                  "Control the suddeness of the sensitivity increase.");
+SYNCHRONOUS_PARAM(
+    MOTIVITY, 98304, // 1.5 << 16
+    "Set the maximum sensitivity while also setting the minimum to "
+    "1/MOTIVITY");
+SYNCHRONOUS_PARAM(
+    SYNC_SPEED, 327680, // 5 << 16
+    "Set The middle sensitivity between you min and max sensitivity");
 #endif
+
+SYNCHRONOUS_PARAM(
+    GAIN, 0, "Interpret the Synchronous curve as gain instead of sensitivity");
+
+static DEFINE_MUTEX(synchronous_gain_update_lock);
+
+static inline void rebuild_synchronous_gain_lut(void) {
+  static struct synchronous_gain_lut next_lut;
+  struct synchronous_curve_args args;
+
+  mutex_lock(&synchronous_gain_update_lock);
+  args = (struct synchronous_curve_args){
+      .gamma = atofp(PARAM_GAMMA),
+      .smooth = atofp(PARAM_SMOOTH),
+      .motivity = atofp(PARAM_MOTIVITY),
+      .sync_speed = atofp(PARAM_SYNC_SPEED),
+      .gain = atofp(PARAM_GAIN),
+  };
+  __synchronous_gain_lut_init(&next_lut, args);
+  publish_synchronous_gain_lut(&next_lut);
+  mutex_unlock(&synchronous_gain_update_lock);
+}
+
+static int set_synchronous_param(const char *value,
+                                 const struct kernel_param *param) {
+  int error = param_set_charp(value, param);
+
+  if (!error)
+    rebuild_synchronous_gain_lut();
+  return error;
+}
+
+static const struct kernel_param_ops synchronous_param_ops = {
+    .set = set_synchronous_param,
+    .get = param_get_charp,
+};
 
 // Flags
 #define PARAM_FLAG(param, default_value, desc)                                 \

--- a/driver/params.h
+++ b/driver/params.h
@@ -121,9 +121,9 @@ static inline struct synchronous_curve_args collect_synchronous_args(void) {
   };
 }
 
-static inline struct synchronous_curve_args
+static inline struct synchronous_gain_curve_args
 collect_synchronous_gain_args(void) {
-  return (struct synchronous_curve_args){
+  return (struct synchronous_gain_curve_args){
       .gamma = atofp(PARAM_SYNC_GAIN_GAMMA),
       .smooth = atofp(PARAM_SYNC_GAIN_SMOOTH),
       .motivity = atofp(PARAM_SYNC_GAIN_MOTIVITY),

--- a/driver/params.h
+++ b/driver/params.h
@@ -12,11 +12,11 @@
   module_param_named(param, PARAM_##param, charp, RW_USER_GROUP);              \
   MODULE_PARM_DESC(param, desc);
 
-static const struct kernel_param_ops synchronous_param_ops;
+static const struct kernel_param_ops synchronous_gain_param_ops;
 
-#define SYNCHRONOUS_PARAM(param, default_value, desc)                          \
+#define SYNCHRONOUS_GAIN_PARAM(param, default_value, desc)                     \
   char *PARAM_##param = #default_value;                                        \
-  module_param_cb(param, &synchronous_param_ops, &PARAM_##param,               \
+  module_param_cb(param, &synchronous_gain_param_ops, &PARAM_##param,          \
                   RW_USER_GROUP);                                              \
   MODULE_PARM_DESC(param, desc);
 
@@ -67,35 +67,50 @@ PARAM(LIMIT, 98304, // 1.5 << 16
 // For Synchronous Mode
 
 #if FIXEDPT_BITS == 64
-SYNCHRONOUS_PARAM(
-    GAMMA, 4294967296, // 1 << 32
-    "Control how fast you get from low to fast around the midpoint");
-SYNCHRONOUS_PARAM(SMOOTH, 2147483648, // 0.5 << 32
-                  "Control the suddeness of the sensitivity increase.");
-SYNCHRONOUS_PARAM(
-    MOTIVITY, 6442450944, // 1.5 << 32
-    "Set the maximum sensitivity while also setting the minimum to "
-    "1/MOTIVITY");
-SYNCHRONOUS_PARAM(
-    SYNC_SPEED, 21474836480, // 5 << 32
-    "Set The middle sensitivity between you min and max sensitivity");
-#else
-SYNCHRONOUS_PARAM(
-    GAMMA, 65536, // 1 << 16
-    "Control how fast you get from low to fast around the midpoint");
-SYNCHRONOUS_PARAM(SMOOTH, 32768, // 0.5 << 16
-                  "Control the suddeness of the sensitivity increase.");
-SYNCHRONOUS_PARAM(
-    MOTIVITY, 98304, // 1.5 << 16
-    "Set the maximum sensitivity while also setting the minimum to "
-    "1/MOTIVITY");
-SYNCHRONOUS_PARAM(
-    SYNC_SPEED, 327680, // 5 << 16
-    "Set The middle sensitivity between you min and max sensitivity");
-#endif
+PARAM(GAMMA, 4294967296, // 1 << 32
+      "Control how fast you get from low to fast around the midpoint");
+PARAM(SMOOTH, 2147483648, // 0.5 << 32
+      "Control the suddeness of the sensitivity increase.");
+PARAM(MOTIVITY, 6442450944, // 1.5 << 32
+      "Set the maximum sensitivity while also setting the minimum to "
+      "1/MOTIVITY");
+PARAM(SYNC_SPEED, 21474836480, // 5 << 32
+      "Set The middle sensitivity between you min and max sensitivity");
 
-SYNCHRONOUS_PARAM(
-    GAIN, 0, "Interpret the Synchronous curve as gain instead of sensitivity");
+SYNCHRONOUS_GAIN_PARAM(
+    SYNC_GAIN_GAMMA, 4294967296, // 1 << 32
+    "Control how fast Synchronous Gain changes around the midpoint");
+SYNCHRONOUS_GAIN_PARAM(
+    SYNC_GAIN_SMOOTH, 2147483648, // 0.5 << 32
+    "Control the suddenness of the Synchronous Gain increase");
+SYNCHRONOUS_GAIN_PARAM(
+    SYNC_GAIN_MOTIVITY, 6442450944, // 1.5 << 32
+    "Set the Synchronous Gain maximum and reciprocal minimum");
+SYNCHRONOUS_GAIN_PARAM(SYNC_GAIN_SPEED, 21474836480, // 5 << 32
+                       "Set the midpoint speed for Synchronous Gain");
+#else
+PARAM(GAMMA, 65536, // 1 << 16
+      "Control how fast you get from low to fast around the midpoint");
+PARAM(SMOOTH, 32768, // 0.5 << 16
+      "Control the suddeness of the sensitivity increase.");
+PARAM(MOTIVITY, 98304, // 1.5 << 16
+      "Set the maximum sensitivity while also setting the minimum to "
+      "1/MOTIVITY");
+PARAM(SYNC_SPEED, 327680, // 5 << 16
+      "Set The middle sensitivity between you min and max sensitivity");
+
+SYNCHRONOUS_GAIN_PARAM(
+    SYNC_GAIN_GAMMA, 65536, // 1 << 16
+    "Control how fast Synchronous Gain changes around the midpoint");
+SYNCHRONOUS_GAIN_PARAM(
+    SYNC_GAIN_SMOOTH, 32768, // 0.5 << 16
+    "Control the suddenness of the Synchronous Gain increase");
+SYNCHRONOUS_GAIN_PARAM(
+    SYNC_GAIN_MOTIVITY, 98304, // 1.5 << 16
+    "Set the Synchronous Gain maximum and reciprocal minimum");
+SYNCHRONOUS_GAIN_PARAM(SYNC_GAIN_SPEED, 327680, // 5 << 16
+                       "Set the midpoint speed for Synchronous Gain");
+#endif
 
 static inline struct synchronous_curve_args collect_synchronous_args(void) {
   return (struct synchronous_curve_args){
@@ -103,21 +118,30 @@ static inline struct synchronous_curve_args collect_synchronous_args(void) {
       .smooth = atofp(PARAM_SMOOTH),
       .motivity = atofp(PARAM_MOTIVITY),
       .sync_speed = atofp(PARAM_SYNC_SPEED),
-      .gain = atofp(PARAM_GAIN),
   };
 }
 
-static int set_synchronous_param(const char *value,
-                                 const struct kernel_param *param) {
+static inline struct synchronous_curve_args
+collect_synchronous_gain_args(void) {
+  return (struct synchronous_curve_args){
+      .gamma = atofp(PARAM_SYNC_GAIN_GAMMA),
+      .smooth = atofp(PARAM_SYNC_GAIN_SMOOTH),
+      .motivity = atofp(PARAM_SYNC_GAIN_MOTIVITY),
+      .sync_speed = atofp(PARAM_SYNC_GAIN_SPEED),
+  };
+}
+
+static int set_synchronous_gain_param(const char *value,
+                                      const struct kernel_param *param) {
   int error = param_set_charp(value, param);
 
   if (!error)
-    update_synchronous_gain_lut(collect_synchronous_args());
+    update_synchronous_gain_lut(collect_synchronous_gain_args());
   return error;
 }
 
-static const struct kernel_param_ops synchronous_param_ops = {
-    .set = set_synchronous_param,
+static const struct kernel_param_ops synchronous_gain_param_ops = {
+    .set = set_synchronous_gain_param,
     .get = param_get_charp,
 };
 

--- a/driver/params.h
+++ b/driver/params.h
@@ -4,7 +4,6 @@
 #include "accel/mode.h"
 #include "fixedptc.h"
 #include "linux/moduleparam.h"
-#include "linux/mutex.h"
 
 #define RW_USER_GROUP 0664
 
@@ -98,23 +97,14 @@ SYNCHRONOUS_PARAM(
 SYNCHRONOUS_PARAM(
     GAIN, 0, "Interpret the Synchronous curve as gain instead of sensitivity");
 
-static DEFINE_MUTEX(synchronous_gain_update_lock);
-
-static inline void rebuild_synchronous_gain_lut(void) {
-  static struct synchronous_gain_lut next_lut;
-  struct synchronous_curve_args args;
-
-  mutex_lock(&synchronous_gain_update_lock);
-  args = (struct synchronous_curve_args){
+static inline struct synchronous_curve_args collect_synchronous_args(void) {
+  return (struct synchronous_curve_args){
       .gamma = atofp(PARAM_GAMMA),
       .smooth = atofp(PARAM_SMOOTH),
       .motivity = atofp(PARAM_MOTIVITY),
       .sync_speed = atofp(PARAM_SYNC_SPEED),
       .gain = atofp(PARAM_GAIN),
   };
-  __synchronous_gain_lut_init(&next_lut, args);
-  publish_synchronous_gain_lut(&next_lut);
-  mutex_unlock(&synchronous_gain_update_lock);
 }
 
 static int set_synchronous_param(const char *value,
@@ -122,7 +112,7 @@ static int set_synchronous_param(const char *value,
   int error = param_set_charp(value, param);
 
   if (!error)
-    rebuild_synchronous_gain_lut();
+    update_synchronous_gain_lut(collect_synchronous_args());
   return error;
 }
 

--- a/driver/speed.h
+++ b/driver/speed.h
@@ -12,11 +12,16 @@
 static fpt LAST_INPUT_MOUSE_SPEED = 0;
 
 static inline fpt input_speed(fpt dx, fpt dy, fpt time_ms) {
+  if (time_ms <= 0) {
+    LAST_INPUT_MOUSE_SPEED = 0;
+    return 0;
+  }
 
   fpt distance = magnitude((struct vector){dx, dy});
 
   if (distance == -1) {
     dbg("distance calculation failed: t = %s", fptoa(time_ms));
+    LAST_INPUT_MOUSE_SPEED = 0;
     return 0;
   }
 

--- a/driver/tests/accel.test.c
+++ b/driver/tests/accel.test.c
@@ -26,9 +26,7 @@ static int test_acceleration(const char *filename, struct accel_args args) {
     }
   }
 
-  assert_snapshot(filename, content);
-
-  return 0;
+  return assert_snapshot(filename, content);
 }
 
 static int test_linear_acceleration(const char *filename, fpt param_sens_mult,
@@ -122,66 +120,97 @@ static int test_rotation_no_accel(const char *filename, fpt param_sens_mult,
   return test_acceleration(filename, args);
 }
 
-#define test_linear(sens_mult, yx_ratio, accel, offset, cap)                   \
-  assert(test_linear_acceleration(                                             \
-             "SENS_MULT-" #sens_mult "-ACCEL-" #accel "-OFFSET" #offset        \
-             "-OUTPUT_CAP-" #cap ".snapshot",                                  \
-             fpt_rconst(sens_mult), fpt_rconst(yx_ratio), fpt_rconst(accel),   \
-             fpt_rconst(offset), fpt_rconst(cap)) == 0);
+#define linear_test(name, sens_mult, yx_ratio, accel, offset, cap)             \
+  TEST name(void) {                                                            \
+    ASSERT_EQ(0, test_linear_acceleration(                                     \
+                     "SENS_MULT-" #sens_mult "-ACCEL-" #accel                  \
+                     "-OFFSET" #offset "-OUTPUT_CAP-" #cap ".snapshot",        \
+                     fpt_rconst(sens_mult), fpt_rconst(yx_ratio),              \
+                     fpt_rconst(accel), fpt_rconst(offset), fpt_rconst(cap))); \
+    PASS();                                                                    \
+  }
 
-#define test_natural(sens_mult, yx_ratio, decay_rate, offset, limit)           \
-  assert(test_natural_acceleration(                                            \
-             "Natural__SENS_MULT-" #sens_mult "-DECAY_RATE-" #decay_rate       \
-             "-OFFSET" #offset "-LIMIT-" #limit ".snapshot",                   \
-             fpt_rconst(sens_mult), fpt_rconst(yx_ratio),                      \
-             fpt_rconst(decay_rate), fpt_rconst(offset),                       \
-             fpt_rconst(limit)) == 0);
+#define natural_test(name, sens_mult, yx_ratio, decay_rate, offset, limit)     \
+  TEST name(void) {                                                            \
+    ASSERT_EQ(0,                                                               \
+              test_natural_acceleration(                                       \
+                  "Natural__SENS_MULT-" #sens_mult "-DECAY_RATE-" #decay_rate  \
+                  "-OFFSET" #offset "-LIMIT-" #limit ".snapshot",              \
+                  fpt_rconst(sens_mult), fpt_rconst(yx_ratio),                 \
+                  fpt_rconst(decay_rate), fpt_rconst(offset),                  \
+                  fpt_rconst(limit)));                                         \
+    PASS();                                                                    \
+  }
 
-#define test_synchronous(sens_mult, yx_ratio, gamma, smooth, motivity,         \
+#define synchronous_test(name, sens_mult, yx_ratio, gamma, smooth, motivity,   \
                          sync_speed)                                           \
-  assert(test_synchronous_acceleration(                                        \
-             "Synchronous__SENS_MULT-" #sens_mult "-GAMMA-" #gamma             \
-             "-SMOOTH" #smooth "-MOTIVITY-" #motivity                          \
-             "-SYNC_SPEED-" #sync_speed ".snapshot",                           \
-             fpt_rconst(sens_mult), fpt_rconst(yx_ratio), fpt_rconst(gamma),   \
-             fpt_rconst(smooth), fpt_rconst(motivity),                         \
-             fpt_rconst(sync_speed)) == 0);
+  TEST name(void) {                                                            \
+    ASSERT_EQ(0, test_synchronous_acceleration(                                \
+                     "Synchronous__SENS_MULT-" #sens_mult "-GAMMA-" #gamma     \
+                     "-SMOOTH" #smooth "-MOTIVITY-" #motivity                  \
+                     "-SYNC_SPEED-" #sync_speed ".snapshot",                   \
+                     fpt_rconst(sens_mult), fpt_rconst(yx_ratio),              \
+                     fpt_rconst(gamma), fpt_rconst(smooth),                    \
+                     fpt_rconst(motivity), fpt_rconst(sync_speed)));           \
+    PASS();                                                                    \
+  }
 
-#define test_no_accel(sens_mult, yx_ratio)                                     \
-  assert(test_no_accel_acceleration(                                           \
-             "NoAccel__SENS_MULT-" #sens_mult "-YX_RATIO-" #yx_ratio           \
-             ".snapshot",                                                      \
-             fpt_rconst(sens_mult), fpt_rconst(yx_ratio)) == 0);
+#define no_accel_test(name, sens_mult, yx_ratio)                               \
+  TEST name(void) {                                                            \
+    ASSERT_EQ(0, test_no_accel_acceleration(                                   \
+                     "NoAccel__SENS_MULT-" #sens_mult "-YX_RATIO-" #yx_ratio   \
+                     ".snapshot",                                              \
+                     fpt_rconst(sens_mult), fpt_rconst(yx_ratio)));            \
+    PASS();                                                                    \
+  }
 
-#define test_rotation(sens_mult, angle_deg)                                    \
-  assert(test_rotation_no_accel(                                               \
-             "Rotation__SENS_MULT-" #sens_mult "-ANGLE-" #angle_deg            \
-             ".snapshot",                                                      \
-             fpt_rconst(sens_mult), fpt_rconst(angle_deg)) == 0);
+#define rotation_test(name, sens_mult, angle_deg)                              \
+  TEST name(void) {                                                            \
+    ASSERT_EQ(0, test_rotation_no_accel("Rotation__SENS_MULT-" #sens_mult      \
+                                        "-ANGLE-" #angle_deg ".snapshot",      \
+                                        fpt_rconst(sens_mult),                 \
+                                        fpt_rconst(angle_deg)));               \
+    PASS();                                                                    \
+  }
 
-int main(void) {
-  test_linear(1, 1, 0, 0, 0);
-  test_linear(1, 1, 0.3, 2, 2);
-  test_linear(0.1325, 1, 0.3, 21.333333, 2);
-  test_linear(0.1875, 1, 0.05625, 10.6666666, 2);
-  test_linear(0.0917, 1, 0.002048, 78.125, 2.0239);
-  test_linear(0.07, 1.15, 0.055, 21, 3);
+linear_test(linear_identity, 1, 1, 0, 0, 0);
+linear_test(linear_default, 1, 1, 0.3, 2, 2);
+linear_test(linear_low_sensitivity, 0.1325, 1, 0.3, 21.333333, 2);
+linear_test(linear_moderate_acceleration, 0.1875, 1, 0.05625, 10.6666666, 2);
+linear_test(linear_low_acceleration, 0.0917, 1, 0.002048, 78.125, 2.0239);
+linear_test(linear_yx_ratio, 0.07, 1.15, 0.055, 21, 3);
+natural_test(natural_identity, 1, 1, 0, 0, 0);
+natural_test(natural_decay, 1, 1, 0.1, 0, 0);
+natural_test(natural_offset, 1, 1, 0.1, 8, 0);
+natural_test(natural_limit, 1, 1, 0.03, 8, 1.5);
+synchronous_test(synchronous_default, 1, 1.15, 0.8, 0.5, 1.5, 32);
+no_accel_test(no_accel_identity, 1, 1);
+no_accel_test(no_accel_yx_ratio, 0.5, 1.5);
+rotation_test(rotation_45_degrees, 1, 45);
+rotation_test(rotation_90_degrees, 1, 90);
 
-  test_natural(1, 1, 0, 0, 0);
-  test_natural(1, 1, 0.1, 0, 0);
-  test_natural(1, 1, 0.1, 8, 0);
-  test_natural(1, 1, 0.03, 8, 1.5);
+SUITE(acceleration) {
+  RUN_TEST(linear_identity);
+  RUN_TEST(linear_default);
+  RUN_TEST(linear_low_sensitivity);
+  RUN_TEST(linear_moderate_acceleration);
+  RUN_TEST(linear_low_acceleration);
+  RUN_TEST(linear_yx_ratio);
+  RUN_TEST(natural_identity);
+  RUN_TEST(natural_decay);
+  RUN_TEST(natural_offset);
+  RUN_TEST(natural_limit);
+  RUN_TEST(synchronous_default);
+  RUN_TEST(no_accel_identity);
+  RUN_TEST(no_accel_yx_ratio);
+  RUN_TEST(rotation_45_degrees);
+  RUN_TEST(rotation_90_degrees);
+}
 
-  test_synchronous(1, 1.15, 0.8, 0.5, 1.5, 32);
+GREATEST_MAIN_DEFS();
 
-  test_no_accel(1, 1);
-  test_no_accel(0.5, 1.5);
-
-  /* Rotation tests: verify cross-axis output when one axis is 0.
-   * At 45 degrees, (10, 0) should produce roughly (7, 7) - not (10, 0).
-   * At 90 degrees, (10, 0) should produce roughly (0, 10). */
-  test_rotation(1, 45);
-  test_rotation(1, 90);
-
-  print_success;
+int main(int argc, char **argv) {
+  TEST_MAIN_BEGIN();
+  RUN_SUITE(acceleration);
+  GREATEST_MAIN_END();
 }

--- a/driver/tests/atofp.test.c
+++ b/driver/tests/atofp.test.c
@@ -1,41 +1,49 @@
 #include "../fixedptc.h"
-#include "./test_utils.h"
-#include <assert.h>
-#include <stdio.h>
+#include "test_utils.h"
 #include <time.h>
 
-void test_eq(char *value, double expected) {
-  fpt n = atofp(value);
-  double actual = fpt_todouble(n);
-  dbg("actual: (%li) %.15f, vs expected: %.15f\n", n, actual, expected);
-  assert(actual == expected);
-}
+#define atofp_test(name, value, expected)                                      \
+  TEST name(void) {                                                            \
+    fpt n = atofp(value);                                                      \
+    double actual = fpt_todouble(n);                                           \
+    dbg("actual: (%li) %.15f, vs expected: %.15f\n", n, actual, expected);     \
+    ASSERT_EQ(expected, actual);                                               \
+    PASS();                                                                    \
+  }
 
-void super_tiny_micro_minuscule_bench() {
+atofp_test(converts_quarter, "1073741824", 0.25);
+atofp_test(converts_eighth, "536870912", 0.125);
+atofp_test(converts_five_sixteenths, "1342177280", 0.3125);
+atofp_test(converts_negative_integer, "-335007449088", -78);
+
+TEST reports_conversion_benchmark(void) {
   int iterations = 100000;
   double sum = 0;
+
   for (int i = 0; i < iterations; i++) {
     struct timespec begin, end;
     clock_gettime(CLOCK_MONOTONIC_RAW, &begin);
-
-    fpt n = atofp("1826512586328");
-    dbg("atofp(\"1826512586328\") = %li\n", n);
-
+    atofp("1826512586328");
     clock_gettime(CLOCK_MONOTONIC_RAW, &end);
     sum += (double)(end.tv_nsec - begin.tv_nsec);
   }
 
-  double avg = sum / iterations;
-  printf("   Avg run time is %fns\n", avg);
+  printf("\n  Average conversion: %fns\n", sum / iterations);
+  PASS();
 }
 
-int main(void) {
-  test_eq("1073741824", 0.25);
-  test_eq("536870912", 0.125);
-  test_eq("1342177280", 0.3125);
-  test_eq("-335007449088", -78);
+SUITE(atofp_conversion) {
+  RUN_TEST(converts_quarter);
+  RUN_TEST(converts_eighth);
+  RUN_TEST(converts_five_sixteenths);
+  RUN_TEST(converts_negative_integer);
+  RUN_TEST(reports_conversion_benchmark);
+}
 
-  print_success;
+GREATEST_MAIN_DEFS();
 
-  super_tiny_micro_minuscule_bench();
+int main(int argc, char **argv) {
+  TEST_MAIN_BEGIN();
+  RUN_SUITE(atofp_conversion);
+  GREATEST_MAIN_END();
 }

--- a/driver/tests/div128_s64.test.c
+++ b/driver/tests/div128_s64.test.c
@@ -1,6 +1,7 @@
 #include "../dbg.h"
 #include "../fixedptc.h"
 #include "test_utils.h"
+#include <sys/wait.h>
 
 #define division_test(name, a, b)                                              \
   TEST name(void) {                                                            \
@@ -15,6 +16,38 @@
     ASSERT_EQ(expected, actual);                                               \
     PASS();                                                                    \
   }
+
+/*
+ * A zero divisor currently raises SIGFPE in the raw idivq helper. The guard
+ * must make division by zero *return* a defined value instead of trapping, so
+ * run it in a forked child and require a clean exit (red now, green after the
+ * guard). This keeps the failure an assertion instead of killing the suite.
+ */
+TEST divides_zero_divisor(void) {
+  pid_t pid = fork();
+  if (pid == -1) {
+    perror("fork");
+    FAILm("fork failed");
+  }
+  if (pid == 0) {
+    freopen("/dev/null", "w", stdout);
+    fpt quotient = div128_s64_s64(fpt_rconst(127), 0);
+    if (quotient != 0)
+      _exit(2);
+    _exit(0);
+  }
+  int status;
+  pid_t result;
+  do {
+    result = waitpid(pid, &status, 0);
+  } while (result == -1 && errno == EINTR);
+  if (result == -1) {
+    perror("waitpid");
+    FAILm("waitpid failed");
+  }
+  ASSERT_EQ_FMTm("division by zero should return zero", 0, status, "%d");
+  PASS();
+}
 
 #if FIXEDPT_BITS == 32
 TEST division_is_not_supported(void) { SKIP(); }
@@ -35,6 +68,7 @@ SUITE(signed_128_bit_division) {
   RUN_TEST(divides_negative_value);
   RUN_TEST(divides_negative_exactly);
   RUN_TEST(divides_positive_fraction);
+  RUN_TEST(divides_zero_divisor);
 #endif
 }
 

--- a/driver/tests/div128_s64.test.c
+++ b/driver/tests/div128_s64.test.c
@@ -1,45 +1,47 @@
 #include "../dbg.h"
 #include "../fixedptc.h"
 #include "test_utils.h"
-#include <assert.h>
-#include <stdint.h>
 
-void test_custom_division_against_fixedpt(double a, double b) {
+#define division_test(name, a, b)                                              \
+  TEST name(void) {                                                            \
+    fpt n = fpt_rconst(a);                                                     \
+    fpt divisor = fpt_rconst(b);                                               \
+    fpt quotient = div128_s64_s64(n, divisor);                                 \
+    fpt expected_quotient = fpt_xdiv(n, divisor);                              \
+    double actual = fpt_todouble(quotient);                                    \
+    double expected = fpt_todouble(expected_quotient);                         \
+    dbg("actual = (%li) -> %.10f", quotient, actual);                          \
+    dbg("expect = (%li) -> %.10f", expected_quotient, expected);               \
+    ASSERT_EQ(expected, actual);                                               \
+    PASS();                                                                    \
+  }
+
 #if FIXEDPT_BITS == 32
-  return;
+TEST division_is_not_supported(void) { SKIP(); }
 #else
+division_test(divides_positive_values, 57, 5.5);
+division_test(divides_zero, 0, 2.57);
+division_test(divides_negative_value, -1, 3);
+division_test(divides_negative_exactly, -128, 4);
+division_test(divides_positive_fraction, 127, 1.5);
+#endif
 
-  fpt n = fpt_rconst(a);
-  fpt divisor = fpt_rconst(b);
-
-  fpt quotient = div128_s64_s64(n, divisor);
-  fpt quotient1 = fpt_xdiv(n, divisor);
-
-  double actual = fpt_todouble(quotient);
-  double expected = fpt_todouble(quotient1);
-
-  dbg("actual = (%li) -> %.10f", quotient, actual);
-  dbg("expect = (%li) -> %.10f", quotient1, expected);
-
-  assert(actual == expected);
+SUITE(signed_128_bit_division) {
+#if FIXEDPT_BITS == 32
+  RUN_TEST(division_is_not_supported);
+#else
+  RUN_TEST(divides_positive_values);
+  RUN_TEST(divides_zero);
+  RUN_TEST(divides_negative_value);
+  RUN_TEST(divides_negative_exactly);
+  RUN_TEST(divides_positive_fraction);
 #endif
 }
 
-int main(void) {
+GREATEST_MAIN_DEFS();
 
-  test_custom_division_against_fixedpt(57, 5.5);
-
-  test_custom_division_against_fixedpt(0, 2.57);
-
-  test_custom_division_against_fixedpt(-1, 3);
-
-  test_custom_division_against_fixedpt(-128, 4);
-
-  test_custom_division_against_fixedpt(127, 1.5);
-
-  /* test_custom_division_against_fixedpth(135, 0); */ // You only crash once!
-
-  print_success;
-
-  return 0;
+int main(int argc, char **argv) {
+  TEST_MAIN_BEGIN();
+  RUN_SUITE(signed_128_bit_division);
+  GREATEST_MAIN_END();
 }

--- a/driver/tests/fp_to_str.test.c
+++ b/driver/tests/fp_to_str.test.c
@@ -1,27 +1,38 @@
 #include "../fixedptc.h"
 #include "test_utils.h"
-#include <assert.h>
-#include <linux/limits.h>
-#include <unistd.h>
 
-int assert_string_value(char *filename, double value) {
+static int assert_string_value(char *filename, double value) {
   fpt v = fpt_rconst(value);
-  char *_v = fptoa(v);
+  char *actual = fptoa(v);
 
-  dbg("to_string %f = %s", value, _v);
-
-  assert_snapshot(filename, _v);
-  return 0;
+  dbg("to_string %f = %s", value, actual);
+  return assert_snapshot(filename, actual);
 }
 
-#define test_str(value)                                                        \
-  assert(assert_string_value(__FILE_NAME__ "_" #value ".snapshot", value) == 0)
+#define fp_to_str_test(name, value)                                            \
+  TEST name(void) {                                                            \
+    ASSERT_EQm(                                                                \
+        "snapshot differs: " __FILE_NAME__ "_" #value ".snapshot", 0,          \
+        assert_string_value(__FILE_NAME__ "_" #value ".snapshot", value));     \
+    PASS();                                                                    \
+  }
 
-int main(void) {
-  test_str(0.25);
-  test_str(0.125);
-  test_str(0.3125);
-  test_str(-785);
+fp_to_str_test(converts_quarter, 0.25);
+fp_to_str_test(converts_eighth, 0.125);
+fp_to_str_test(converts_five_sixteenths, 0.3125);
+fp_to_str_test(converts_negative_integer, -785);
 
-  print_success;
+SUITE(fp_to_str) {
+  RUN_TEST(converts_quarter);
+  RUN_TEST(converts_eighth);
+  RUN_TEST(converts_five_sixteenths);
+  RUN_TEST(converts_negative_integer);
+}
+
+GREATEST_MAIN_DEFS();
+
+int main(int argc, char **argv) {
+  TEST_MAIN_BEGIN();
+  RUN_SUITE(fp_to_str);
+  GREATEST_MAIN_END();
 }

--- a/driver/tests/guard_division.test.c
+++ b/driver/tests/guard_division.test.c
@@ -1,0 +1,146 @@
+#include "../accel.h"
+#include "test_utils.h"
+#include <sys/wait.h>
+
+/*
+ * Encode the proper behavior on invalid timing / divisors: the call must
+ * complete (no SIGFPE in userspace, no #DE in kernel). Each case runs in a
+ * forked child because the current implementation traps with SIGFPE; the
+ * guard makes these pass.
+ */
+
+static int run_child_exit(void (*fn)(void)) {
+  pid_t pid = fork();
+  if (pid == -1) {
+    perror("fork");
+    return -1;
+  }
+  if (pid == 0) {
+    /* Silence stdout so dbg() noise from a crashing child doesn't pollute
+     * the Greatest report; only the child's exit status is observed. */
+    freopen("/dev/null", "w", stdout);
+    fn();
+    _exit(0);
+  }
+  int status;
+  pid_t result;
+  do {
+    result = waitpid(pid, &status, 0);
+  } while (result == -1 && errno == EINTR);
+  if (result == -1) {
+    perror("waitpid");
+    return -1;
+  }
+  return status;
+}
+
+static struct accel_args default_linear_args(void) {
+  struct linear_curve_args lin = {
+      .accel = fpt_rconst(0.3), .offset = fpt_rconst(2), .output_cap = 0};
+  struct accel_args args = {
+      .sens_mult = FIXEDPT_ONE,
+      .yx_ratio = FIXEDPT_ONE,
+      .input_dpi = fpt_fromint(1000),
+      .angle_rotation_deg = 0,
+      .tag = linear,
+      .args = (union __accel_args){.linear = lin},
+  };
+  return args;
+}
+
+static struct accel_args default_synchronous_args(void) {
+  struct synchronous_curve_args sync = {.gamma = fpt_rconst(0.8),
+                                        .smooth = fpt_rconst(0.5),
+                                        .motivity = fpt_rconst(1.5),
+                                        .sync_speed = fpt_rconst(32)};
+  struct accel_args args = {
+      .sens_mult = FIXEDPT_ONE,
+      .yx_ratio = FIXEDPT_ONE,
+      .input_dpi = fpt_fromint(1000),
+      .angle_rotation_deg = 0,
+      .tag = synchronous,
+      .args = (union __accel_args){.synchronous = sync},
+  };
+  return args;
+}
+
+/* --- crash cases: run each in a child and require clean survival --- */
+
+static void child_input_speed_zero_time(void) {
+  fpt speed = input_speed(fpt_fromint(10), fpt_fromint(5), 0);
+  if (speed != 0)
+    _exit(2);
+}
+
+TEST input_speed_time_zero_returns_zero(void) {
+  int status = run_child_exit(child_input_speed_zero_time);
+  ASSERT_EQ_FMTm("input_speed(time=0) should return zero", 0, status, "%d");
+  PASS();
+}
+
+static void child_input_dpi_zero(void) {
+  struct accel_args args = default_linear_args();
+  args.input_dpi = 0;
+  int x = 10, y = 5;
+  f_accelerate(&x, &y, FIXEDPT_ONE, args);
+}
+
+TEST faccelerate_input_dpi_zero_survives(void) {
+  int status = run_child_exit(child_input_dpi_zero);
+  ASSERT_EQ_FMTm("f_accelerate(input_dpi=0) should not crash", 0, status, "%d");
+  PASS();
+}
+
+static void child_motivity_one(void) {
+  struct accel_args args = default_synchronous_args();
+  args.args.synchronous.motivity = FIXEDPT_ONE; /* ln(1) == 0 divisor */
+  int x = 10, y = 5;
+  f_accelerate(&x, &y, FIXEDPT_ONE, args);
+}
+
+TEST synchronous_motivity_one_survives(void) {
+  int status = run_child_exit(child_motivity_one);
+  ASSERT_EQ_FMTm("synchronous(motivity=1) should not crash", 0, status, "%d");
+  PASS();
+}
+
+/* --- asserted values --- */
+
+static void child_faccelerate_time_zero_identity(void) {
+  struct accel_args args = default_linear_args();
+  int x = 10, y = 5;
+  f_accelerate(&x, &y, 0, args);
+  /* encode the intended behavior: no acceleration on a zero-time frame */
+  if (x != 10 || y != 5)
+    _exit(2);
+}
+
+TEST faccelerate_time_zero_identity(void) {
+  int status = run_child_exit(child_faccelerate_time_zero_identity);
+  ASSERT_EQ_FMTm("should not crash", 0, status, "%d");
+  PASS();
+}
+
+static void child_input_speed_negative_time(void) {
+  fpt speed = input_speed(fpt_fromint(10), fpt_fromint(5), -FIXEDPT_ONE);
+  if (speed != 0)
+    _exit(3);
+}
+
+TEST input_speed_negative_time_returns_zero(void) {
+  int status = run_child_exit(child_input_speed_negative_time);
+  ASSERT_EQ_FMTm("input_speed(time<0) should return zero", 0, status, "%d");
+  PASS();
+}
+
+GREATEST_MAIN_DEFS();
+
+int main(int argc, char **argv) {
+  TEST_MAIN_BEGIN();
+  RUN_TEST(input_speed_time_zero_returns_zero);
+  RUN_TEST(faccelerate_input_dpi_zero_survives);
+  RUN_TEST(synchronous_motivity_one_survives);
+  RUN_TEST(faccelerate_time_zero_identity);
+  RUN_TEST(input_speed_negative_time_returns_zero);
+  GREATEST_MAIN_END();
+}

--- a/driver/tests/input_speed.test.c
+++ b/driver/tests/input_speed.test.c
@@ -1,48 +1,58 @@
 #include "../speed.h"
-#include "./test_utils.h"
-#include <stdio.h>
+#include "test_utils.h"
 
-int assert_string_value(char *filename, double x, double y, double t) {
+static int assert_string_value(char *filename, double x, double y, double t) {
   fpt dx = fpt_rconst(x);
   fpt dy = fpt_rconst(y);
   fpt dt = fpt_rconst(t);
+  fpt speed = input_speed(dx, dy, dt);
+  double result = fpt_todouble(speed);
+  char content[100];
 
-  dbg("in                        (%f, %f)", x, y);
+  dbg("in (%f, %f)", x, y);
   dbg("in: x (fpt conversion) %s", fptoa(x));
   dbg("in: y (fpt conversion) %s", fptoa(y));
+  dbg("(%f, %f) dt = %f -> %f\n", x, y, t, result);
+  sprintf(content, "(sqrt(%f, %f) / %f) = %f\n", x, y, t, result);
 
-  fpt s = input_speed(dx, dy, dt);
-
-  double res = fpt_todouble(s);
-  dbg("(%f, %f) dt = %f -> %f\n", x, y, t, res);
-
-  char content[100];
-  sprintf(content, "(sqrt(%f, %f) / %f) = %f\n", x, y, t, res);
-
-  assert_snapshot(filename, content);
-
-  return 0;
+  return assert_snapshot(filename, content);
 }
 
-#define test(x, y, time)                                                       \
-  assert(assert_string_value(__FILE_NAME__ "_sqrt_" #x "_" #y "_" #time        \
-                                           ".snapshot",                        \
-                             x, y, time) == 0)
+#define input_speed_test(name, x, y, time)                                     \
+  TEST name(void) {                                                            \
+    ASSERT_EQm("snapshot differs: " __FILE_NAME__ "_sqrt_" #x "_" #y "_" #time \
+               ".snapshot",                                                    \
+               0,                                                              \
+               assert_string_value(__FILE_NAME__ "_sqrt_" #x "_" #y "_" #time  \
+                                                 ".snapshot",                  \
+                                   x, y, time));                               \
+    PASS();                                                                    \
+  }
 
-int main(void) {
-  test(1, 1, 1);
-  test(1, 21, 1);
-  test(64, -37, 1);
-  test(1, 4, 1);
+input_speed_test(speed_1_1_1, 1, 1, 1);
+input_speed_test(speed_1_21_1, 1, 21, 1);
+input_speed_test(speed_64_negative_37_1, 64, -37, 1);
+input_speed_test(speed_1_4_1, 1, 4, 1);
+input_speed_test(speed_negative_1_1_4, -1, 1, 4);
+input_speed_test(speed_1_0_100, 1, 0, 100);
+input_speed_test(speed_1_negative_1_100, 1, -1, 100);
+input_speed_test(speed_negative_1_negative_24_1, -1, -24, 1);
 
-  test(-1, 1, 4);
+SUITE(input_speed_snapshots) {
+  RUN_TEST(speed_1_1_1);
+  RUN_TEST(speed_1_21_1);
+  RUN_TEST(speed_64_negative_37_1);
+  RUN_TEST(speed_1_4_1);
+  RUN_TEST(speed_negative_1_1_4);
+  RUN_TEST(speed_1_0_100);
+  RUN_TEST(speed_1_negative_1_100);
+  RUN_TEST(speed_negative_1_negative_24_1);
+}
 
-  test(1, 0, 100);
+GREATEST_MAIN_DEFS();
 
-  test(1, -1, 100);
-
-  test(-1, -24, 1);
-
-  print_success;
-  return 0;
+int main(int argc, char **argv) {
+  TEST_MAIN_BEGIN();
+  RUN_SUITE(input_speed_snapshots);
+  GREATEST_MAIN_END();
 }

--- a/driver/tests/synchronous_gain.test.c
+++ b/driver/tests/synchronous_gain.test.c
@@ -1,4 +1,4 @@
-#include "../accel/synchronous.h"
+#include "../accel.h"
 #include "test_utils.h"
 
 static int fpt_near(fpt actual, fpt expected, fpt tolerance) {
@@ -11,7 +11,6 @@ TEST matches_raw_accel_reference(void) {
       .smooth = fpt_rconst(0.5),
       .motivity = fpt_rconst(1.5),
       .sync_speed = fpt_rconst(32),
-      .gain = FIXEDPT_ONE,
   };
   struct synchronous_gain_lut lut;
 #if FIXEDPT_BITS == 64
@@ -51,15 +50,43 @@ TEST clamps_sensitivity_below_first_point(void) {
   PASS();
 }
 
-SUITE(synchronous_gain) {
+TEST is_a_separate_acceleration_mode(void) {
+  struct synchronous_curve_args curve = {
+      .gamma = fpt_rconst(0.8),
+      .smooth = fpt_rconst(0.5),
+      .motivity = fpt_rconst(1.5),
+      .sync_speed = fpt_rconst(32),
+  };
+  struct accel_args gain_args = {
+      .sens_mult = FIXEDPT_ONE,
+      .yx_ratio = FIXEDPT_ONE,
+      .tag = synchronous_gain,
+      .args = (union __accel_args){.synchronous_gain = curve},
+  };
+  struct accel_args legacy_args = {
+      .sens_mult = FIXEDPT_ONE,
+      .yx_ratio = FIXEDPT_ONE,
+      .tag = synchronous,
+      .args = (union __accel_args){.synchronous = curve},
+  };
+  struct vector gain = sensitivity(fpt_rconst(32), gain_args);
+  struct vector legacy = sensitivity(fpt_rconst(32), legacy_args);
+
+  ASSERT(fpt_near(gain.x, fpt_rconst(0.7544606092), fpt_rconst(0.0002)));
+  ASSERT_EQ(FIXEDPT_ONE, legacy.x);
+  PASS();
+}
+
+SUITE(synchronous_gain_tests) {
   RUN_TEST(matches_raw_accel_reference);
   RUN_TEST(clamps_sensitivity_below_first_point);
+  RUN_TEST(is_a_separate_acceleration_mode);
 }
 
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
   GREATEST_MAIN_BEGIN();
-  RUN_SUITE(synchronous_gain);
+  RUN_SUITE(synchronous_gain_tests);
   GREATEST_MAIN_END();
 }

--- a/driver/tests/synchronous_gain.test.c
+++ b/driver/tests/synchronous_gain.test.c
@@ -6,7 +6,7 @@ static int fpt_near(fpt actual, fpt expected, fpt tolerance) {
 }
 
 TEST matches_raw_accel_reference(void) {
-  struct synchronous_curve_args args = {
+  struct synchronous_gain_curve_args args = {
       .gamma = fpt_rconst(0.8),
       .smooth = fpt_rconst(0.5),
       .motivity = fpt_rconst(1.5),
@@ -35,7 +35,7 @@ TEST matches_raw_accel_reference(void) {
 }
 
 TEST clamps_sensitivity_below_first_point(void) {
-  struct synchronous_curve_args args = {
+  struct synchronous_gain_curve_args args = {
       .gamma = fpt_rconst(0.8),
       .smooth = fpt_rconst(0.5),
       .motivity = fpt_rconst(1.5),
@@ -51,7 +51,7 @@ TEST clamps_sensitivity_below_first_point(void) {
 }
 
 TEST is_a_separate_acceleration_mode(void) {
-  struct synchronous_curve_args curve = {
+  struct synchronous_gain_curve_args gain_curve = {
       .gamma = fpt_rconst(0.8),
       .smooth = fpt_rconst(0.5),
       .motivity = fpt_rconst(1.5),
@@ -61,13 +61,22 @@ TEST is_a_separate_acceleration_mode(void) {
       .sens_mult = FIXEDPT_ONE,
       .yx_ratio = FIXEDPT_ONE,
       .tag = synchronous_gain,
-      .args = (union __accel_args){.synchronous_gain = curve},
+      .args = (union __accel_args){.synchronous_gain = gain_curve},
   };
   struct accel_args legacy_args = {
       .sens_mult = FIXEDPT_ONE,
       .yx_ratio = FIXEDPT_ONE,
       .tag = synchronous,
-      .args = (union __accel_args){.synchronous = curve},
+      .args =
+          (union __accel_args){
+              .synchronous =
+                  {
+                      .gamma = fpt_rconst(0.8),
+                      .smooth = fpt_rconst(0.5),
+                      .motivity = fpt_rconst(1.5),
+                      .sync_speed = fpt_rconst(32),
+                  },
+          },
   };
   struct vector gain = sensitivity(fpt_rconst(32), gain_args);
   struct vector legacy = sensitivity(fpt_rconst(32), legacy_args);

--- a/driver/tests/synchronous_gain.test.c
+++ b/driver/tests/synchronous_gain.test.c
@@ -1,0 +1,65 @@
+#include "../accel/synchronous.h"
+#include "test_utils.h"
+
+static int fpt_near(fpt actual, fpt expected, fpt tolerance) {
+  return fpt_abs(actual - expected) <= tolerance;
+}
+
+TEST matches_raw_accel_reference(void) {
+  struct synchronous_curve_args args = {
+      .gamma = fpt_rconst(0.8),
+      .smooth = fpt_rconst(0.5),
+      .motivity = fpt_rconst(1.5),
+      .sync_speed = fpt_rconst(32),
+      .gain = FIXEDPT_ONE,
+  };
+  struct synchronous_gain_lut lut;
+#if FIXEDPT_BITS == 64
+  const fpt tolerance = fpt_rconst(0.0002);
+#else
+  const fpt tolerance = fpt_rconst(0.002);
+#endif
+
+  __synchronous_gain_lut_init(&lut, args);
+
+  ASSERT(fpt_near(__synchronous_gain_lut_lookup(fpt_rconst(0.125), &lut),
+                  fpt_rconst(0.6666666668), tolerance));
+  ASSERT(fpt_near(__synchronous_gain_lut_lookup(fpt_rconst(5), &lut),
+                  fpt_rconst(0.6667458263), tolerance));
+  ASSERT(fpt_near(__synchronous_gain_lut_lookup(fpt_rconst(32), &lut),
+                  fpt_rconst(0.7544606092), tolerance));
+  ASSERT(fpt_near(__synchronous_gain_lut_lookup(fpt_rconst(512), &lut),
+                  fpt_rconst(1.4372989449), tolerance));
+  ASSERT(fpt_near(__synchronous_gain_lut_lookup(fpt_rconst(1024), &lut),
+                  fpt_rconst(1.4686379769), tolerance));
+  PASS();
+}
+
+TEST clamps_sensitivity_below_first_point(void) {
+  struct synchronous_curve_args args = {
+      .gamma = fpt_rconst(0.8),
+      .smooth = fpt_rconst(0.5),
+      .motivity = fpt_rconst(1.5),
+      .sync_speed = fpt_rconst(32),
+  };
+  struct synchronous_gain_lut lut;
+
+  __synchronous_gain_lut_init(&lut, args);
+
+  ASSERT_EQ(__synchronous_gain_lut_lookup(fpt_rconst(0.125), &lut),
+            __synchronous_gain_lut_lookup(fpt_rconst(0.01), &lut));
+  PASS();
+}
+
+SUITE(synchronous_gain) {
+  RUN_TEST(matches_raw_accel_reference);
+  RUN_TEST(clamps_sensitivity_below_first_point);
+}
+
+GREATEST_MAIN_DEFS();
+
+int main(int argc, char **argv) {
+  GREATEST_MAIN_BEGIN();
+  RUN_SUITE(synchronous_gain);
+  GREATEST_MAIN_END();
+}

--- a/driver/tests/test_utils.h
+++ b/driver/tests/test_utils.h
@@ -1,5 +1,7 @@
-#include <assert.h>
+#include <errno.h>
 #include <linux/limits.h>
+#include <signal.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -7,52 +9,113 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-static int diff(const char *content, const char *filename) {
+#define COLOR_RESET "\033[0m"
+#define COLOR_BOLD "\033[1m"
+#define COLOR_RED "\033[31m"
+#define COLOR_GREEN "\033[32m"
+#define COLOR_YELLOW "\033[33m"
+#define COLOR_CYAN "\033[36m"
 
+static int colors_enabled(FILE *stream) {
+  return isatty(fileno(stream)) && getenv("NO_COLOR") == NULL;
+}
+
+/* These prefixes track format strings emitted by Greatest 1.5.0. */
+static const char *test_output_color(const char *format) {
+  if (strcmp(format, ".") == 0 || strncmp(format, "PASS ", 5) == 0)
+    return COLOR_GREEN;
+  if (strcmp(format, "F") == 0 || strncmp(format, "FAIL ", 5) == 0)
+    return COLOR_RED;
+  if (strcmp(format, "s") == 0 || strncmp(format, "SKIP ", 5) == 0)
+    return COLOR_YELLOW;
+  if (strncmp(format, "\n* Suite ", 9) == 0)
+    return COLOR_CYAN;
+  if (strncmp(format, "\nTotal: ", 8) == 0 || strncmp(format, "Pass: ", 6) == 0)
+    return COLOR_BOLD;
+  return NULL;
+}
+
+static int test_fprintf(FILE *stream, const char *format, ...) {
+  const char *color = colors_enabled(stream) ? test_output_color(format) : NULL;
+  va_list args;
+  int result;
+
+  if (color != NULL)
+    fputs(color, stream);
+  va_start(args, format);
+  result = vfprintf(stream, format, args);
+  va_end(args);
+  if (color != NULL)
+    fputs(COLOR_RESET, stream);
+  return result;
+}
+
+#define GREATEST_FPRINTF test_fprintf
+#include "vendor/greatest.h"
+
+#define TEST_MAIN_BEGIN()                                                      \
+  do {                                                                         \
+    GREATEST_MAIN_BEGIN();                                                     \
+    if (greatest_get_verbosity() == 0)                                         \
+      greatest_set_verbosity(1);                                               \
+  } while (0)
+
+static void print_diff(const char *content, const char *filename) {
   int pipe_fd[2];
   pid_t child_pid;
+  struct sigaction ignore_sigpipe = {.sa_handler = SIG_IGN};
+  struct sigaction previous_sigpipe;
 
-  // Create a pipe for communication
+  fflush(stdout);
   if (pipe(pipe_fd) == -1) {
-    perror("Pipe creation failed");
-    exit(EXIT_FAILURE);
+    perror("failed to create snapshot diff pipe");
+    return;
   }
 
-  // Fork the process
   if ((child_pid = fork()) == -1) {
-    perror("Fork failed");
-    exit(EXIT_FAILURE);
-  }
-
-  if (child_pid == 0) { // Child process
-    // Close the write end of the pipe
-    close(pipe_fd[1]);
-
-    // Redirect stdin to read from the pipe
-    dup2(pipe_fd[0], STDIN_FILENO);
-
-    // Execute a command (e.g., "wc -l")
-    execlp("diff", "diff", "-u", "--color", filename, "-", NULL);
-
-    // If execlp fails
-    perror("Exec failed");
-    exit(EXIT_FAILURE);
-  } else { // Parent process
-    // Close the read end of the pipe
+    perror("failed to fork snapshot diff");
     close(pipe_fd[0]);
-
-    // Write data to the child process
-    if (write(pipe_fd[1], content, strlen(content)) == -1) {
-      perror("failed to write content to the pipe for diff");
-    }
-
     close(pipe_fd[1]);
-
-    // Wait for the child process to finish
-    wait(NULL);
+    return;
   }
 
-  return 0;
+  if (child_pid == 0) {
+    close(pipe_fd[1]);
+    dup2(pipe_fd[0], STDIN_FILENO);
+    close(pipe_fd[0]);
+    if (colors_enabled(stdout))
+      execlp("diff", "diff", "-u", "--color=always", filename, "-", NULL);
+    else
+      execlp("diff", "diff", "-u", filename, "-", NULL);
+    perror("failed to execute diff");
+    exit(EXIT_FAILURE);
+  }
+
+  close(pipe_fd[0]);
+  sigemptyset(&ignore_sigpipe.sa_mask);
+  if (sigaction(SIGPIPE, &ignore_sigpipe, &previous_sigpipe) == -1) {
+    perror("failed to ignore SIGPIPE while writing snapshot diff");
+  } else {
+    size_t content_length = strlen(content);
+    size_t bytes_written = 0;
+
+    while (bytes_written < content_length) {
+      ssize_t result = write(pipe_fd[1], content + bytes_written,
+                             content_length - bytes_written);
+      if (result > 0) {
+        bytes_written += result;
+      } else if (result == -1 && errno == EINTR) {
+        continue;
+      } else {
+        perror("failed to write snapshot content to diff");
+        break;
+      }
+    }
+    if (sigaction(SIGPIPE, &previous_sigpipe, NULL) == -1)
+      perror("failed to restore SIGPIPE handler");
+  }
+  close(pipe_fd[1]);
+  waitpid(child_pid, NULL, 0);
 }
 
 static int get_current_working_dir(char *buf, size_t buf_size) {
@@ -70,15 +133,18 @@ static char *create_snapshot_file_path(const char *filename) {
   };
 
   static char filepath[PATH_MAX];
-  sprintf(filepath, "%s/tests/snapshots/%s", cwd, filename);
+  if (snprintf(filepath, sizeof(filepath), "%s/tests/snapshots/%s", cwd,
+               filename) >= (int)sizeof(filepath)) {
+    fprintf(stderr, "snapshot path is too long: %s\n", filename);
+    return NULL;
+  }
   return filepath;
 }
 
-static void assert_snapshot(const char *__filename, const char *content) {
+static int assert_snapshot(const char *__filename, const char *content) {
   char *filename = create_snapshot_file_path(__filename);
   if (filename == NULL) {
-    fprintf(stderr, "failed to create snapshot file: %s\n", filename);
-    exit(1);
+    return 1;
   }
 
   int snapshot_file_exists = access(filename, F_OK) != -1;
@@ -93,45 +159,50 @@ static void assert_snapshot(const char *__filename, const char *content) {
   if (snapshot_file == NULL) {
     fprintf(stderr, "failed to open or create the snapshot file: %s\n",
             filename);
-    exit(1);
+    return 1;
   }
 
   if (snapshot_file_exists) {
     struct stat stats;
-    int file_size;
+    size_t file_size;
 
-    stat(filename, &stats);
-    file_size = stats.st_size;
-    char *snapshot = (char *)malloc(stats.st_size + 1);
+    if (stat(filename, &stats) != 0) {
+      perror("failed to stat snapshot file");
+      fclose(snapshot_file);
+      return 1;
+    }
+    file_size = (size_t)stats.st_size;
+    char *snapshot = (char *)malloc(file_size + 1);
 
     if (snapshot == NULL) {
       fprintf(stderr,
               "failed to allocate %zd bytes of a string for the snapshot "
               "content in file: %s\n",
               stats.st_size, filename);
-      exit(1);
+      fclose(snapshot_file);
+      return 1;
     }
 
     size_t bytes_read = fread(snapshot, 1, file_size, snapshot_file);
     if (bytes_read != file_size) {
       fprintf(stderr, "failed to read a snapshot file %s\n", filename);
-      exit(1);
+      free(snapshot);
+      fclose(snapshot_file);
+      return 1;
     }
     snapshot[file_size] = 0; // null byte terminator
 
-    int string_test_diff = strcmp(snapshot, content);
-
-    diff(content, filename);
-
-    /* dbg("diff in content = %d: snapshot '%s' vs now '%s'", string_test, */
-    /*     snapshot, content); */
-    assert(string_test_diff == 0);
+    int snapshot_differs = strcmp(snapshot, content);
+    free(snapshot);
+    if (snapshot_differs)
+      print_diff(content, filename);
+    fclose(snapshot_file);
+    return snapshot_differs != 0;
   } else {
     fprintf(snapshot_file, "%s", content);
-    printf("created a snapshot file %s\n", filename);
+    printf("NEW  %s\n", filename);
   }
 
   fclose(snapshot_file);
+  return 0;
 }
-
-#define print_success printf("[%s]\t\tAll tests passed!\n", __FILE_NAME__)

--- a/driver/tests/vendor/greatest.h
+++ b/driver/tests/vendor/greatest.h
@@ -1,0 +1,1266 @@
+/*
+ * Copyright (c) 2011-2021 Scott Vokes <vokes.s@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef GREATEST_H
+#define GREATEST_H
+
+#if defined(__cplusplus) && !defined(GREATEST_NO_EXTERN_CPLUSPLUS)
+extern "C" {
+#endif
+
+/* 1.5.0 */
+#define GREATEST_VERSION_MAJOR 1
+#define GREATEST_VERSION_MINOR 5
+#define GREATEST_VERSION_PATCH 0
+
+/* A unit testing system for C, contained in 1 file.
+ * It doesn't use dynamic allocation or depend on anything
+ * beyond ANSI C89.
+ *
+ * An up-to-date version can be found at:
+ *     https://github.com/silentbicycle/greatest/
+ */
+
+
+/*********************************************************************
+ * Minimal test runner template
+ *********************************************************************/
+#if 0
+
+#include "greatest.h"
+
+TEST foo_should_foo(void) {
+    PASS();
+}
+
+static void setup_cb(void *data) {
+    printf("setup callback for each test case\n");
+}
+
+static void teardown_cb(void *data) {
+    printf("teardown callback for each test case\n");
+}
+
+SUITE(suite) {
+    /* Optional setup/teardown callbacks which will be run before/after
+     * every test case. If using a test suite, they will be cleared when
+     * the suite finishes. */
+    SET_SETUP(setup_cb, voidp_to_callback_data);
+    SET_TEARDOWN(teardown_cb, voidp_to_callback_data);
+
+    RUN_TEST(foo_should_foo);
+}
+
+/* Add definitions that need to be in the test runner's main file. */
+GREATEST_MAIN_DEFS();
+
+/* Set up, run suite(s) of tests, report pass/fail/skip stats. */
+int run_tests(void) {
+    GREATEST_INIT();            /* init. greatest internals */
+    /* List of suites to run (if any). */
+    RUN_SUITE(suite);
+
+    /* Tests can also be run directly, without using test suites. */
+    RUN_TEST(foo_should_foo);
+
+    GREATEST_PRINT_REPORT();          /* display results */
+    return greatest_all_passed();
+}
+
+/* main(), for a standalone command-line test runner.
+ * This replaces run_tests above, and adds command line option
+ * handling and exiting with a pass/fail status. */
+int main(int argc, char **argv) {
+    GREATEST_MAIN_BEGIN();      /* init & parse command-line args */
+    RUN_SUITE(suite);
+    GREATEST_MAIN_END();        /* display results */
+}
+
+#endif
+/*********************************************************************/
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+/***********
+ * Options *
+ ***********/
+
+/* Default column width for non-verbose output. */
+#ifndef GREATEST_DEFAULT_WIDTH
+#define GREATEST_DEFAULT_WIDTH 72
+#endif
+
+/* FILE *, for test logging. */
+#ifndef GREATEST_STDOUT
+#define GREATEST_STDOUT stdout
+#endif
+
+/* Remove GREATEST_ prefix from most commonly used symbols? */
+#ifndef GREATEST_USE_ABBREVS
+#define GREATEST_USE_ABBREVS 1
+#endif
+
+/* Set to 0 to disable all use of setjmp/longjmp. */
+#ifndef GREATEST_USE_LONGJMP
+#define GREATEST_USE_LONGJMP 0
+#endif
+
+/* Make it possible to replace fprintf with another
+ * function with the same interface. */
+#ifndef GREATEST_FPRINTF
+#define GREATEST_FPRINTF fprintf
+#endif
+
+#if GREATEST_USE_LONGJMP
+#include <setjmp.h>
+#endif
+
+/* Set to 0 to disable all use of time.h / clock(). */
+#ifndef GREATEST_USE_TIME
+#define GREATEST_USE_TIME 1
+#endif
+
+#if GREATEST_USE_TIME
+#include <time.h>
+#endif
+
+/* Floating point type, for ASSERT_IN_RANGE. */
+#ifndef GREATEST_FLOAT
+#define GREATEST_FLOAT double
+#define GREATEST_FLOAT_FMT "%g"
+#endif
+
+/* Size of buffer for test name + optional '_' separator and suffix */
+#ifndef GREATEST_TESTNAME_BUF_SIZE
+#define GREATEST_TESTNAME_BUF_SIZE 128
+#endif
+
+
+/*********
+ * Types *
+ *********/
+
+/* Info for the current running suite. */
+typedef struct greatest_suite_info {
+    unsigned int tests_run;
+    unsigned int passed;
+    unsigned int failed;
+    unsigned int skipped;
+
+#if GREATEST_USE_TIME
+    /* timers, pre/post running suite and individual tests */
+    clock_t pre_suite;
+    clock_t post_suite;
+    clock_t pre_test;
+    clock_t post_test;
+#endif
+} greatest_suite_info;
+
+/* Type for a suite function. */
+typedef void greatest_suite_cb(void);
+
+/* Types for setup/teardown callbacks. If non-NULL, these will be run
+ * and passed the pointer to their additional data. */
+typedef void greatest_setup_cb(void *udata);
+typedef void greatest_teardown_cb(void *udata);
+
+/* Type for an equality comparison between two pointers of the same type.
+ * Should return non-0 if equal, otherwise 0.
+ * UDATA is a closure value, passed through from ASSERT_EQUAL_T[m]. */
+typedef int greatest_equal_cb(const void *expd, const void *got, void *udata);
+
+/* Type for a callback that prints a value pointed to by T.
+ * Return value has the same meaning as printf's.
+ * UDATA is a closure value, passed through from ASSERT_EQUAL_T[m]. */
+typedef int greatest_printf_cb(const void *t, void *udata);
+
+/* Callbacks for an arbitrary type; needed for type-specific
+ * comparisons via GREATEST_ASSERT_EQUAL_T[m].*/
+typedef struct greatest_type_info {
+    greatest_equal_cb *equal;
+    greatest_printf_cb *print;
+} greatest_type_info;
+
+typedef struct greatest_memory_cmp_env {
+    const unsigned char *exp;
+    const unsigned char *got;
+    size_t size;
+} greatest_memory_cmp_env;
+
+/* Callbacks for string and raw memory types. */
+extern greatest_type_info greatest_type_info_string;
+extern greatest_type_info greatest_type_info_memory;
+
+typedef enum {
+    GREATEST_FLAG_FIRST_FAIL = 0x01,
+    GREATEST_FLAG_LIST_ONLY = 0x02,
+    GREATEST_FLAG_ABORT_ON_FAIL = 0x04
+} greatest_flag_t;
+
+/* Internal state for a PRNG, used to shuffle test order. */
+struct greatest_prng {
+    unsigned char random_order; /* use random ordering? */
+    unsigned char initialized;  /* is random ordering initialized? */
+    unsigned char pad_0[6];
+    unsigned long state;        /* PRNG state */
+    unsigned long count;        /* how many tests, this pass */
+    unsigned long count_ceil;   /* total number of tests */
+    unsigned long count_run;    /* total tests run */
+    unsigned long a;            /* LCG multiplier */
+    unsigned long c;            /* LCG increment */
+    unsigned long m;            /* LCG modulus, based on count_ceil */
+};
+
+/* Struct containing all test runner state. */
+typedef struct greatest_run_info {
+    unsigned char flags;
+    unsigned char verbosity;
+    unsigned char running_test; /* guard for nested RUN_TEST calls */
+    unsigned char exact_name_match;
+
+    unsigned int tests_run;     /* total test count */
+
+    /* currently running test suite */
+    greatest_suite_info suite;
+
+    /* overall pass/fail/skip counts */
+    unsigned int passed;
+    unsigned int failed;
+    unsigned int skipped;
+    unsigned int assertions;
+
+    /* info to print about the most recent failure */
+    unsigned int fail_line;
+    unsigned int pad_1;
+    const char *fail_file;
+    const char *msg;
+
+    /* current setup/teardown hooks and userdata */
+    greatest_setup_cb *setup;
+    void *setup_udata;
+    greatest_teardown_cb *teardown;
+    void *teardown_udata;
+
+    /* formatting info for ".....s...F"-style output */
+    unsigned int col;
+    unsigned int width;
+
+    /* only run a specific suite or test */
+    const char *suite_filter;
+    const char *test_filter;
+    const char *test_exclude;
+    const char *name_suffix;    /* print suffix with test name */
+    char name_buf[GREATEST_TESTNAME_BUF_SIZE];
+
+    struct greatest_prng prng[2]; /* 0: suites, 1: tests */
+
+#if GREATEST_USE_TIME
+    /* overall timers */
+    clock_t begin;
+    clock_t end;
+#endif
+
+#if GREATEST_USE_LONGJMP
+    int pad_jmp_buf;
+    unsigned char pad_2[4];
+    jmp_buf jump_dest;
+#endif
+} greatest_run_info;
+
+struct greatest_report_t {
+    /* overall pass/fail/skip counts */
+    unsigned int passed;
+    unsigned int failed;
+    unsigned int skipped;
+    unsigned int assertions;
+};
+
+/* Global var for the current testing context.
+ * Initialized by GREATEST_MAIN_DEFS(). */
+extern greatest_run_info greatest_info;
+
+/* Type for ASSERT_ENUM_EQ's ENUM_STR argument. */
+typedef const char *greatest_enum_str_fun(int value);
+
+
+/**********************
+ * Exported functions *
+ **********************/
+
+/* These are used internally by greatest macros. */
+int greatest_test_pre(const char *name);
+void greatest_test_post(int res);
+int greatest_do_assert_equal_t(const void *expd, const void *got,
+    greatest_type_info *type_info, void *udata);
+void greatest_prng_init_first_pass(int id);
+int greatest_prng_init_second_pass(int id, unsigned long seed);
+void greatest_prng_step(int id);
+
+/* These are part of the public greatest API. */
+void GREATEST_SET_SETUP_CB(greatest_setup_cb *cb, void *udata);
+void GREATEST_SET_TEARDOWN_CB(greatest_teardown_cb *cb, void *udata);
+void GREATEST_INIT(void);
+void GREATEST_PRINT_REPORT(void);
+int greatest_all_passed(void);
+void greatest_set_suite_filter(const char *filter);
+void greatest_set_test_filter(const char *filter);
+void greatest_set_test_exclude(const char *filter);
+void greatest_set_exact_name_match(void);
+void greatest_stop_at_first_fail(void);
+void greatest_abort_on_fail(void);
+void greatest_list_only(void);
+void greatest_get_report(struct greatest_report_t *report);
+unsigned int greatest_get_verbosity(void);
+void greatest_set_verbosity(unsigned int verbosity);
+void greatest_set_flag(greatest_flag_t flag);
+void greatest_set_test_suffix(const char *suffix);
+
+
+/********************
+* Language Support *
+********************/
+
+/* If __VA_ARGS__ (C99) is supported, allow parametric testing
+* without needing to manually manage the argument struct. */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 19901L) ||        \
+    (defined(_MSC_VER) && _MSC_VER >= 1800)
+#define GREATEST_VA_ARGS
+#endif
+
+
+/**********
+ * Macros *
+ **********/
+
+/* Define a suite. (The duplication is intentional -- it eliminates
+ * a warning from -Wmissing-declarations.) */
+#define GREATEST_SUITE(NAME) void NAME(void); void NAME(void)
+
+/* Declare a suite, provided by another compilation unit. */
+#define GREATEST_SUITE_EXTERN(NAME) void NAME(void)
+
+/* Start defining a test function.
+ * The arguments are not included, to allow parametric testing. */
+#define GREATEST_TEST static enum greatest_test_res
+
+/* PASS/FAIL/SKIP result from a test. Used internally. */
+typedef enum greatest_test_res {
+    GREATEST_TEST_RES_PASS = 0,
+    GREATEST_TEST_RES_FAIL = -1,
+    GREATEST_TEST_RES_SKIP = 1
+} greatest_test_res;
+
+/* Run a suite. */
+#define GREATEST_RUN_SUITE(S_NAME) greatest_run_suite(S_NAME, #S_NAME)
+
+/* Run a test in the current suite. */
+#define GREATEST_RUN_TEST(TEST)                                         \
+    do {                                                                \
+        if (greatest_test_pre(#TEST) == 1) {                            \
+            enum greatest_test_res res = GREATEST_SAVE_CONTEXT();       \
+            if (res == GREATEST_TEST_RES_PASS) {                        \
+                res = TEST();                                           \
+            }                                                           \
+            greatest_test_post(res);                                    \
+        }                                                               \
+    } while (0)
+
+/* Ignore a test, don't warn about it being unused. */
+#define GREATEST_IGNORE_TEST(TEST) (void)TEST
+
+/* Run a test in the current suite with one void * argument,
+ * which can be a pointer to a struct with multiple arguments. */
+#define GREATEST_RUN_TEST1(TEST, ENV)                                   \
+    do {                                                                \
+        if (greatest_test_pre(#TEST) == 1) {                            \
+            enum greatest_test_res res = GREATEST_SAVE_CONTEXT();       \
+            if (res == GREATEST_TEST_RES_PASS) {                        \
+                res = TEST(ENV);                                        \
+            }                                                           \
+            greatest_test_post(res);                                    \
+        }                                                               \
+    } while (0)
+
+#ifdef GREATEST_VA_ARGS
+#define GREATEST_RUN_TESTp(TEST, ...)                                   \
+    do {                                                                \
+        if (greatest_test_pre(#TEST) == 1) {                            \
+            enum greatest_test_res res = GREATEST_SAVE_CONTEXT();       \
+            if (res == GREATEST_TEST_RES_PASS) {                        \
+                res = TEST(__VA_ARGS__);                                \
+            }                                                           \
+            greatest_test_post(res);                                    \
+        }                                                               \
+    } while (0)
+#endif
+
+
+/* Check if the test runner is in verbose mode. */
+#define GREATEST_IS_VERBOSE() ((greatest_info.verbosity) > 0)
+#define GREATEST_LIST_ONLY()                                            \
+    (greatest_info.flags & GREATEST_FLAG_LIST_ONLY)
+#define GREATEST_FIRST_FAIL()                                           \
+    (greatest_info.flags & GREATEST_FLAG_FIRST_FAIL)
+#define GREATEST_ABORT_ON_FAIL()                                        \
+    (greatest_info.flags & GREATEST_FLAG_ABORT_ON_FAIL)
+#define GREATEST_FAILURE_ABORT()                                        \
+    (GREATEST_FIRST_FAIL() &&                                           \
+        (greatest_info.suite.failed > 0 || greatest_info.failed > 0))
+
+/* Message-less forms of tests defined below. */
+#define GREATEST_PASS() GREATEST_PASSm(NULL)
+#define GREATEST_FAIL() GREATEST_FAILm(NULL)
+#define GREATEST_SKIP() GREATEST_SKIPm(NULL)
+#define GREATEST_ASSERT(COND)                                           \
+    GREATEST_ASSERTm(#COND, COND)
+#define GREATEST_ASSERT_OR_LONGJMP(COND)                                \
+    GREATEST_ASSERT_OR_LONGJMPm(#COND, COND)
+#define GREATEST_ASSERT_FALSE(COND)                                     \
+    GREATEST_ASSERT_FALSEm(#COND, COND)
+#define GREATEST_ASSERT_EQ(EXP, GOT)                                    \
+    GREATEST_ASSERT_EQm(#EXP " != " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_NEQ(EXP, GOT)                                   \
+    GREATEST_ASSERT_NEQm(#EXP " == " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_GT(EXP, GOT)                                    \
+    GREATEST_ASSERT_GTm(#EXP " <= " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_GTE(EXP, GOT)                                   \
+    GREATEST_ASSERT_GTEm(#EXP " < " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_LT(EXP, GOT)                                    \
+    GREATEST_ASSERT_LTm(#EXP " >= " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_LTE(EXP, GOT)                                   \
+    GREATEST_ASSERT_LTEm(#EXP " > " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_EQ_FMT(EXP, GOT, FMT)                           \
+    GREATEST_ASSERT_EQ_FMTm(#EXP " != " #GOT, EXP, GOT, FMT)
+#define GREATEST_ASSERT_IN_RANGE(EXP, GOT, TOL)                         \
+    GREATEST_ASSERT_IN_RANGEm(#EXP " != " #GOT " +/- " #TOL, EXP, GOT, TOL)
+#define GREATEST_ASSERT_EQUAL_T(EXP, GOT, TYPE_INFO, UDATA)             \
+    GREATEST_ASSERT_EQUAL_Tm(#EXP " != " #GOT, EXP, GOT, TYPE_INFO, UDATA)
+#define GREATEST_ASSERT_STR_EQ(EXP, GOT)                                \
+    GREATEST_ASSERT_STR_EQm(#EXP " != " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_STRN_EQ(EXP, GOT, SIZE)                         \
+    GREATEST_ASSERT_STRN_EQm(#EXP " != " #GOT, EXP, GOT, SIZE)
+#define GREATEST_ASSERT_MEM_EQ(EXP, GOT, SIZE)                          \
+    GREATEST_ASSERT_MEM_EQm(#EXP " != " #GOT, EXP, GOT, SIZE)
+#define GREATEST_ASSERT_ENUM_EQ(EXP, GOT, ENUM_STR)                     \
+    GREATEST_ASSERT_ENUM_EQm(#EXP " != " #GOT, EXP, GOT, ENUM_STR)
+
+/* The following forms take an additional message argument first,
+ * to be displayed by the test runner. */
+
+/* Fail if a condition is not true, with message. */
+#define GREATEST_ASSERTm(MSG, COND)                                     \
+    do {                                                                \
+        greatest_info.assertions++;                                     \
+        if (!(COND)) { GREATEST_FAILm(MSG); }                           \
+    } while (0)
+
+/* Fail if a condition is not true, longjmping out of test. */
+#define GREATEST_ASSERT_OR_LONGJMPm(MSG, COND)                          \
+    do {                                                                \
+        greatest_info.assertions++;                                     \
+        if (!(COND)) { GREATEST_FAIL_WITH_LONGJMPm(MSG); }              \
+    } while (0)
+
+/* Fail if a condition is not false, with message. */
+#define GREATEST_ASSERT_FALSEm(MSG, COND)                               \
+    do {                                                                \
+        greatest_info.assertions++;                                     \
+        if ((COND)) { GREATEST_FAILm(MSG); }                            \
+    } while (0)
+
+/* Internal macro for relational assertions */
+#define GREATEST__REL(REL, MSG, EXP, GOT)                               \
+    do {                                                                \
+        greatest_info.assertions++;                                     \
+        if (!((EXP) REL (GOT))) { GREATEST_FAILm(MSG); }                \
+    } while (0)
+
+/* Fail if EXP is not ==, !=, >, <, >=, or <= to GOT. */
+#define GREATEST_ASSERT_EQm(MSG,E,G) GREATEST__REL(==, MSG,E,G)
+#define GREATEST_ASSERT_NEQm(MSG,E,G) GREATEST__REL(!=, MSG,E,G)
+#define GREATEST_ASSERT_GTm(MSG,E,G) GREATEST__REL(>, MSG,E,G)
+#define GREATEST_ASSERT_GTEm(MSG,E,G) GREATEST__REL(>=, MSG,E,G)
+#define GREATEST_ASSERT_LTm(MSG,E,G) GREATEST__REL(<, MSG,E,G)
+#define GREATEST_ASSERT_LTEm(MSG,E,G) GREATEST__REL(<=, MSG,E,G)
+
+/* Fail if EXP != GOT (equality comparison by ==).
+ * Warning: FMT, EXP, and GOT will be evaluated more
+ * than once on failure. */
+#define GREATEST_ASSERT_EQ_FMTm(MSG, EXP, GOT, FMT)                     \
+    do {                                                                \
+        greatest_info.assertions++;                                     \
+        if ((EXP) != (GOT)) {                                           \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\nExpected: ");          \
+            GREATEST_FPRINTF(GREATEST_STDOUT, FMT, EXP);                \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\n     Got: ");          \
+            GREATEST_FPRINTF(GREATEST_STDOUT, FMT, GOT);                \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                    \
+            GREATEST_FAILm(MSG);                                        \
+        }                                                               \
+    } while (0)
+
+/* Fail if EXP is not equal to GOT, printing enum IDs. */
+#define GREATEST_ASSERT_ENUM_EQm(MSG, EXP, GOT, ENUM_STR)               \
+    do {                                                                \
+        int greatest_EXP = (int)(EXP);                                  \
+        int greatest_GOT = (int)(GOT);                                  \
+        greatest_enum_str_fun *greatest_ENUM_STR = ENUM_STR;            \
+        if (greatest_EXP != greatest_GOT) {                             \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\nExpected: %s",         \
+                greatest_ENUM_STR(greatest_EXP));                       \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\n     Got: %s\n",       \
+                greatest_ENUM_STR(greatest_GOT));                       \
+            GREATEST_FAILm(MSG);                                        \
+        }                                                               \
+    } while (0)                                                         \
+
+/* Fail if GOT not in range of EXP +|- TOL. */
+#define GREATEST_ASSERT_IN_RANGEm(MSG, EXP, GOT, TOL)                   \
+    do {                                                                \
+        GREATEST_FLOAT greatest_EXP = (EXP);                            \
+        GREATEST_FLOAT greatest_GOT = (GOT);                            \
+        GREATEST_FLOAT greatest_TOL = (TOL);                            \
+        greatest_info.assertions++;                                     \
+        if ((greatest_EXP > greatest_GOT &&                             \
+                greatest_EXP - greatest_GOT > greatest_TOL) ||          \
+            (greatest_EXP < greatest_GOT &&                             \
+                greatest_GOT - greatest_EXP > greatest_TOL)) {          \
+            GREATEST_FPRINTF(GREATEST_STDOUT,                           \
+                "\nExpected: " GREATEST_FLOAT_FMT                       \
+                " +/- " GREATEST_FLOAT_FMT                              \
+                "\n     Got: " GREATEST_FLOAT_FMT                       \
+                "\n",                                                   \
+                greatest_EXP, greatest_TOL, greatest_GOT);              \
+            GREATEST_FAILm(MSG);                                        \
+        }                                                               \
+    } while (0)
+
+/* Fail if EXP is not equal to GOT, according to strcmp. */
+#define GREATEST_ASSERT_STR_EQm(MSG, EXP, GOT)                          \
+    do {                                                                \
+        GREATEST_ASSERT_EQUAL_Tm(MSG, EXP, GOT,                         \
+            &greatest_type_info_string, NULL);                          \
+    } while (0)                                                         \
+
+/* Fail if EXP is not equal to GOT, according to strncmp. */
+#define GREATEST_ASSERT_STRN_EQm(MSG, EXP, GOT, SIZE)                   \
+    do {                                                                \
+        size_t size = SIZE;                                             \
+        GREATEST_ASSERT_EQUAL_Tm(MSG, EXP, GOT,                         \
+            &greatest_type_info_string, &size);                         \
+    } while (0)                                                         \
+
+/* Fail if EXP is not equal to GOT, according to memcmp. */
+#define GREATEST_ASSERT_MEM_EQm(MSG, EXP, GOT, SIZE)                    \
+    do {                                                                \
+        greatest_memory_cmp_env env;                                    \
+        env.exp = (const unsigned char *)EXP;                           \
+        env.got = (const unsigned char *)GOT;                           \
+        env.size = SIZE;                                                \
+        GREATEST_ASSERT_EQUAL_Tm(MSG, env.exp, env.got,                 \
+            &greatest_type_info_memory, &env);                          \
+    } while (0)                                                         \
+
+/* Fail if EXP is not equal to GOT, according to a comparison
+ * callback in TYPE_INFO. If they are not equal, optionally use a
+ * print callback in TYPE_INFO to print them. */
+#define GREATEST_ASSERT_EQUAL_Tm(MSG, EXP, GOT, TYPE_INFO, UDATA)       \
+    do {                                                                \
+        greatest_type_info *type_info = (TYPE_INFO);                    \
+        greatest_info.assertions++;                                     \
+        if (!greatest_do_assert_equal_t(EXP, GOT,                       \
+                type_info, UDATA)) {                                    \
+            if (type_info == NULL || type_info->equal == NULL) {        \
+                GREATEST_FAILm("type_info->equal callback missing!");   \
+            } else {                                                    \
+                GREATEST_FAILm(MSG);                                    \
+            }                                                           \
+        }                                                               \
+    } while (0)                                                         \
+
+/* Pass. */
+#define GREATEST_PASSm(MSG)                                             \
+    do {                                                                \
+        greatest_info.msg = MSG;                                        \
+        return GREATEST_TEST_RES_PASS;                                  \
+    } while (0)
+
+/* Fail. */
+#define GREATEST_FAILm(MSG)                                             \
+    do {                                                                \
+        greatest_info.fail_file = __FILE__;                             \
+        greatest_info.fail_line = __LINE__;                             \
+        greatest_info.msg = MSG;                                        \
+        if (GREATEST_ABORT_ON_FAIL()) { abort(); }                      \
+        return GREATEST_TEST_RES_FAIL;                                  \
+    } while (0)
+
+/* Optional GREATEST_FAILm variant that longjmps. */
+#if GREATEST_USE_LONGJMP
+#define GREATEST_FAIL_WITH_LONGJMP() GREATEST_FAIL_WITH_LONGJMPm(NULL)
+#define GREATEST_FAIL_WITH_LONGJMPm(MSG)                                \
+    do {                                                                \
+        greatest_info.fail_file = __FILE__;                             \
+        greatest_info.fail_line = __LINE__;                             \
+        greatest_info.msg = MSG;                                        \
+        longjmp(greatest_info.jump_dest, GREATEST_TEST_RES_FAIL);       \
+    } while (0)
+#endif
+
+/* Skip the current test. */
+#define GREATEST_SKIPm(MSG)                                             \
+    do {                                                                \
+        greatest_info.msg = MSG;                                        \
+        return GREATEST_TEST_RES_SKIP;                                  \
+    } while (0)
+
+/* Check the result of a subfunction using ASSERT, etc. */
+#define GREATEST_CHECK_CALL(RES)                                        \
+    do {                                                                \
+        enum greatest_test_res greatest_RES = RES;                      \
+        if (greatest_RES != GREATEST_TEST_RES_PASS) {                   \
+            return greatest_RES;                                        \
+        }                                                               \
+    } while (0)                                                         \
+
+#if GREATEST_USE_TIME
+#define GREATEST_SET_TIME(NAME)                                         \
+    NAME = clock();                                                     \
+    if (NAME == (clock_t) -1) {                                         \
+        GREATEST_FPRINTF(GREATEST_STDOUT,                               \
+            "clock error: %s\n", #NAME);                                \
+        exit(EXIT_FAILURE);                                             \
+    }
+
+#define GREATEST_CLOCK_DIFF(C1, C2)                                     \
+    GREATEST_FPRINTF(GREATEST_STDOUT, " (%lu ticks, %.3f sec)",         \
+        (long unsigned int) (C2) - (long unsigned int)(C1),             \
+        (double)((C2) - (C1)) / (1.0 * (double)CLOCKS_PER_SEC))
+#else
+#define GREATEST_SET_TIME(UNUSED)
+#define GREATEST_CLOCK_DIFF(UNUSED1, UNUSED2)
+#endif
+
+#if GREATEST_USE_LONGJMP
+#define GREATEST_SAVE_CONTEXT()                                         \
+        /* setjmp returns 0 (GREATEST_TEST_RES_PASS) on first call *    \
+         * so the test runs, then RES_FAIL from FAIL_WITH_LONGJMP. */   \
+        ((enum greatest_test_res)(setjmp(greatest_info.jump_dest)))
+#else
+#define GREATEST_SAVE_CONTEXT()                                         \
+    /*a no-op, since setjmp/longjmp aren't being used */                \
+    GREATEST_TEST_RES_PASS
+#endif
+
+/* Run every suite / test function run within BODY in pseudo-random
+ * order, seeded by SEED. (The top 3 bits of the seed are ignored.)
+ *
+ * This should be called like:
+ *     GREATEST_SHUFFLE_TESTS(seed, {
+ *         GREATEST_RUN_TEST(some_test);
+ *         GREATEST_RUN_TEST(some_other_test);
+ *         GREATEST_RUN_TEST(yet_another_test);
+ *     });
+ *
+ * Note that the body of the second argument will be evaluated
+ * multiple times. */
+#define GREATEST_SHUFFLE_SUITES(SD, BODY) GREATEST_SHUFFLE(0, SD, BODY)
+#define GREATEST_SHUFFLE_TESTS(SD, BODY) GREATEST_SHUFFLE(1, SD, BODY)
+#define GREATEST_SHUFFLE(ID, SD, BODY)                                  \
+    do {                                                                \
+        struct greatest_prng *prng = &greatest_info.prng[ID];           \
+        greatest_prng_init_first_pass(ID);                              \
+        do {                                                            \
+            prng->count = 0;                                            \
+            if (prng->initialized) { greatest_prng_step(ID); }          \
+            BODY;                                                       \
+            if (!prng->initialized) {                                   \
+                if (!greatest_prng_init_second_pass(ID, SD)) { break; } \
+            } else if (prng->count_run == prng->count_ceil) {           \
+                break;                                                  \
+            }                                                           \
+        } while (!GREATEST_FAILURE_ABORT());                            \
+        prng->count_run = prng->random_order = prng->initialized = 0;   \
+    } while(0)
+
+/* Include several function definitions in the main test file. */
+#define GREATEST_MAIN_DEFS()                                            \
+                                                                        \
+/* Is FILTER a subset of NAME? */                                       \
+static int greatest_name_match(const char *name, const char *filter,    \
+        int res_if_none) {                                              \
+    size_t offset = 0;                                                  \
+    size_t filter_len = filter ? strlen(filter) : 0;                    \
+    if (filter_len == 0) { return res_if_none; } /* no filter */        \
+    if (greatest_info.exact_name_match && strlen(name) != filter_len) { \
+        return 0; /* ignore substring matches */                        \
+    }                                                                   \
+    while (name[offset] != '\0') {                                      \
+        if (name[offset] == filter[0]) {                                \
+            if (0 == strncmp(&name[offset], filter, filter_len)) {      \
+                return 1;                                               \
+            }                                                           \
+        }                                                               \
+        offset++;                                                       \
+    }                                                                   \
+                                                                        \
+    return 0;                                                           \
+}                                                                       \
+                                                                        \
+static void greatest_buffer_test_name(const char *name) {               \
+    struct greatest_run_info *g = &greatest_info;                       \
+    size_t len = strlen(name), size = sizeof(g->name_buf);              \
+    memset(g->name_buf, 0x00, size);                                    \
+    (void)strncat(g->name_buf, name, size - 1);                         \
+    if (g->name_suffix && (len + 1 < size)) {                           \
+        g->name_buf[len] = '_';                                         \
+        strncat(&g->name_buf[len+1], g->name_suffix, size-(len+2));     \
+    }                                                                   \
+}                                                                       \
+                                                                        \
+/* Before running a test, check the name filtering and                  \
+ * test shuffling state, if applicable, and then call setup hooks. */   \
+int greatest_test_pre(const char *name) {                               \
+    struct greatest_run_info *g = &greatest_info;                       \
+    int match;                                                          \
+    greatest_buffer_test_name(name);                                    \
+    match = greatest_name_match(g->name_buf, g->test_filter, 1) &&      \
+      !greatest_name_match(g->name_buf, g->test_exclude, 0);            \
+    if (GREATEST_LIST_ONLY()) {   /* just listing test names */         \
+        if (match) {                                                    \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "  %s\n", g->name_buf);   \
+        }                                                               \
+        goto clear;                                                     \
+    }                                                                   \
+    if (match && (!GREATEST_FIRST_FAIL() || g->suite.failed == 0)) {    \
+            struct greatest_prng *p = &g->prng[1];                      \
+        if (p->random_order) {                                          \
+            p->count++;                                                 \
+            if (!p->initialized || ((p->count - 1) != p->state)) {      \
+                goto clear;       /* don't run this test yet */         \
+            }                                                           \
+        }                                                               \
+        if (g->running_test) {                                          \
+            fprintf(stderr, "Error: Test run inside another test.\n");  \
+            return 0;                                                   \
+        }                                                               \
+        GREATEST_SET_TIME(g->suite.pre_test);                           \
+        if (g->setup) { g->setup(g->setup_udata); }                     \
+        p->count_run++;                                                 \
+        g->running_test = 1;                                            \
+        return 1;                 /* test should be run */              \
+    } else {                                                            \
+        goto clear;               /* skipped */                         \
+    }                                                                   \
+clear:                                                                  \
+    g->name_suffix = NULL;                                              \
+    return 0;                                                           \
+}                                                                       \
+                                                                        \
+static void greatest_do_pass(void) {                                    \
+    struct greatest_run_info *g = &greatest_info;                       \
+    if (GREATEST_IS_VERBOSE()) {                                        \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "PASS %s: %s",                \
+            g->name_buf, g->msg ? g->msg : "");                         \
+    } else {                                                            \
+        GREATEST_FPRINTF(GREATEST_STDOUT, ".");                         \
+    }                                                                   \
+    g->suite.passed++;                                                  \
+}                                                                       \
+                                                                        \
+static void greatest_do_fail(void) {                                    \
+    struct greatest_run_info *g = &greatest_info;                       \
+    if (GREATEST_IS_VERBOSE()) {                                        \
+        GREATEST_FPRINTF(GREATEST_STDOUT,                               \
+            "FAIL %s: %s (%s:%u)", g->name_buf,                         \
+            g->msg ? g->msg : "", g->fail_file, g->fail_line);          \
+    } else {                                                            \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "F");                         \
+        g->col++;  /* add linebreak if in line of '.'s */               \
+        if (g->col != 0) {                                              \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                    \
+            g->col = 0;                                                 \
+        }                                                               \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "FAIL %s: %s (%s:%u)\n",      \
+            g->name_buf, g->msg ? g->msg : "",                          \
+            g->fail_file, g->fail_line);                                \
+    }                                                                   \
+    g->suite.failed++;                                                  \
+}                                                                       \
+                                                                        \
+static void greatest_do_skip(void) {                                    \
+    struct greatest_run_info *g = &greatest_info;                       \
+    if (GREATEST_IS_VERBOSE()) {                                        \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "SKIP %s: %s",                \
+            g->name_buf, g->msg ? g->msg : "");                         \
+    } else {                                                            \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "s");                         \
+    }                                                                   \
+    g->suite.skipped++;                                                 \
+}                                                                       \
+                                                                        \
+void greatest_test_post(int res) {                                      \
+    GREATEST_SET_TIME(greatest_info.suite.post_test);                   \
+    if (greatest_info.teardown) {                                       \
+        void *udata = greatest_info.teardown_udata;                     \
+        greatest_info.teardown(udata);                                  \
+    }                                                                   \
+                                                                        \
+    greatest_info.running_test = 0;                                     \
+    if (res <= GREATEST_TEST_RES_FAIL) {                                \
+        greatest_do_fail();                                             \
+    } else if (res >= GREATEST_TEST_RES_SKIP) {                         \
+        greatest_do_skip();                                             \
+    } else if (res == GREATEST_TEST_RES_PASS) {                         \
+        greatest_do_pass();                                             \
+    }                                                                   \
+    greatest_info.name_suffix = NULL;                                   \
+    greatest_info.suite.tests_run++;                                    \
+    greatest_info.col++;                                                \
+    if (GREATEST_IS_VERBOSE()) {                                        \
+        GREATEST_CLOCK_DIFF(greatest_info.suite.pre_test,               \
+            greatest_info.suite.post_test);                             \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                        \
+    } else if (greatest_info.col % greatest_info.width == 0) {          \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                        \
+        greatest_info.col = 0;                                          \
+    }                                                                   \
+    fflush(GREATEST_STDOUT);                                            \
+}                                                                       \
+                                                                        \
+static void report_suite(void) {                                        \
+    if (greatest_info.suite.tests_run > 0) {                            \
+        GREATEST_FPRINTF(GREATEST_STDOUT,                               \
+            "\n%u test%s - %u passed, %u failed, %u skipped",           \
+            greatest_info.suite.tests_run,                              \
+            greatest_info.suite.tests_run == 1 ? "" : "s",              \
+            greatest_info.suite.passed,                                 \
+            greatest_info.suite.failed,                                 \
+            greatest_info.suite.skipped);                               \
+        GREATEST_CLOCK_DIFF(greatest_info.suite.pre_suite,              \
+            greatest_info.suite.post_suite);                            \
+        GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                        \
+    }                                                                   \
+}                                                                       \
+                                                                        \
+static void update_counts_and_reset_suite(void) {                       \
+    greatest_info.setup = NULL;                                         \
+    greatest_info.setup_udata = NULL;                                   \
+    greatest_info.teardown = NULL;                                      \
+    greatest_info.teardown_udata = NULL;                                \
+    greatest_info.passed += greatest_info.suite.passed;                 \
+    greatest_info.failed += greatest_info.suite.failed;                 \
+    greatest_info.skipped += greatest_info.suite.skipped;               \
+    greatest_info.tests_run += greatest_info.suite.tests_run;           \
+    memset(&greatest_info.suite, 0, sizeof(greatest_info.suite));       \
+    greatest_info.col = 0;                                              \
+}                                                                       \
+                                                                        \
+static int greatest_suite_pre(const char *suite_name) {                 \
+    struct greatest_prng *p = &greatest_info.prng[0];                   \
+    if (!greatest_name_match(suite_name, greatest_info.suite_filter, 1) \
+        || (GREATEST_FAILURE_ABORT())) { return 0; }                    \
+    if (p->random_order) {                                              \
+        p->count++;                                                     \
+        if (!p->initialized || ((p->count - 1) != p->state)) {          \
+            return 0; /* don't run this suite yet */                    \
+        }                                                               \
+    }                                                                   \
+    p->count_run++;                                                     \
+    update_counts_and_reset_suite();                                    \
+    GREATEST_FPRINTF(GREATEST_STDOUT, "\n* Suite %s:\n", suite_name);   \
+    GREATEST_SET_TIME(greatest_info.suite.pre_suite);                   \
+    return 1;                                                           \
+}                                                                       \
+                                                                        \
+static void greatest_suite_post(void) {                                 \
+    GREATEST_SET_TIME(greatest_info.suite.post_suite);                  \
+    report_suite();                                                     \
+}                                                                       \
+                                                                        \
+static void greatest_run_suite(greatest_suite_cb *suite_cb,             \
+                               const char *suite_name) {                \
+    if (greatest_suite_pre(suite_name)) {                               \
+        suite_cb();                                                     \
+        greatest_suite_post();                                          \
+    }                                                                   \
+}                                                                       \
+                                                                        \
+int greatest_do_assert_equal_t(const void *expd, const void *got,       \
+        greatest_type_info *type_info, void *udata) {                   \
+    int eq = 0;                                                         \
+    if (type_info == NULL || type_info->equal == NULL) { return 0; }    \
+    eq = type_info->equal(expd, got, udata);                            \
+    if (!eq) {                                                          \
+        if (type_info->print != NULL) {                                 \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\nExpected: ");          \
+            (void)type_info->print(expd, udata);                        \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\n     Got: ");          \
+            (void)type_info->print(got, udata);                         \
+            GREATEST_FPRINTF(GREATEST_STDOUT, "\n");                    \
+        }                                                               \
+    }                                                                   \
+    return eq;                                                          \
+}                                                                       \
+                                                                        \
+static void greatest_usage(const char *name) {                          \
+    GREATEST_FPRINTF(GREATEST_STDOUT,                                   \
+        "Usage: %s [-hlfavex] [-s SUITE] [-t TEST] [-x EXCLUDE]\n"      \
+        "  -h, --help  print this Help\n"                               \
+        "  -l          List suites and tests, then exit (dry run)\n"    \
+        "  -f          Stop runner after first failure\n"               \
+        "  -a          Abort on first failure (implies -f)\n"           \
+        "  -v          Verbose output\n"                                \
+        "  -s SUITE    only run suites containing substring SUITE\n"    \
+        "  -t TEST     only run tests containing substring TEST\n"      \
+        "  -e          only run exact name match for -s or -t\n"        \
+        "  -x EXCLUDE  exclude tests containing substring EXCLUDE\n",   \
+        name);                                                          \
+}                                                                       \
+                                                                        \
+static void greatest_parse_options(int argc, char **argv) {             \
+    int i = 0;                                                          \
+    for (i = 1; i < argc; i++) {                                        \
+        if (argv[i][0] == '-') {                                        \
+            char f = argv[i][1];                                        \
+            if ((f == 's' || f == 't' || f == 'x') && argc <= i + 1) {  \
+                greatest_usage(argv[0]); exit(EXIT_FAILURE);            \
+            }                                                           \
+            switch (f) {                                                \
+            case 's': /* suite name filter */                           \
+                greatest_set_suite_filter(argv[i + 1]); i++; break;     \
+            case 't': /* test name filter */                            \
+                greatest_set_test_filter(argv[i + 1]); i++; break;      \
+            case 'x': /* test name exclusion */                         \
+                greatest_set_test_exclude(argv[i + 1]); i++; break;     \
+            case 'e': /* exact name match */                            \
+                greatest_set_exact_name_match(); break;                 \
+            case 'f': /* first fail flag */                             \
+                greatest_stop_at_first_fail(); break;                   \
+            case 'a': /* abort() on fail flag */                        \
+                greatest_abort_on_fail(); break;                        \
+            case 'l': /* list only (dry run) */                         \
+                greatest_list_only(); break;                            \
+            case 'v': /* first fail flag */                             \
+                greatest_info.verbosity++; break;                       \
+            case 'h': /* help */                                        \
+                greatest_usage(argv[0]); exit(EXIT_SUCCESS);            \
+            default:                                                    \
+            case '-':                                                   \
+                if (0 == strncmp("--help", argv[i], 6)) {               \
+                    greatest_usage(argv[0]); exit(EXIT_SUCCESS);        \
+                } else if (0 == strcmp("--", argv[i])) {                \
+                    return; /* ignore following arguments */            \
+                }                                                       \
+                GREATEST_FPRINTF(GREATEST_STDOUT,                       \
+                    "Unknown argument '%s'\n", argv[i]);                \
+                greatest_usage(argv[0]);                                \
+                exit(EXIT_FAILURE);                                     \
+            }                                                           \
+        }                                                               \
+    }                                                                   \
+}                                                                       \
+                                                                        \
+int greatest_all_passed(void) { return (greatest_info.failed == 0); }   \
+                                                                        \
+void greatest_set_test_filter(const char *filter) {                     \
+    greatest_info.test_filter = filter;                                 \
+}                                                                       \
+                                                                        \
+void greatest_set_test_exclude(const char *filter) {                    \
+    greatest_info.test_exclude = filter;                                \
+}                                                                       \
+                                                                        \
+void greatest_set_suite_filter(const char *filter) {                    \
+    greatest_info.suite_filter = filter;                                \
+}                                                                       \
+                                                                        \
+void greatest_set_exact_name_match(void) {                              \
+    greatest_info.exact_name_match = 1;                                 \
+}                                                                       \
+                                                                        \
+void greatest_stop_at_first_fail(void) {                                \
+    greatest_set_flag(GREATEST_FLAG_FIRST_FAIL);                        \
+}                                                                       \
+                                                                        \
+void greatest_abort_on_fail(void) {                                     \
+    greatest_set_flag(GREATEST_FLAG_ABORT_ON_FAIL);                     \
+}                                                                       \
+                                                                        \
+void greatest_list_only(void) {                                         \
+    greatest_set_flag(GREATEST_FLAG_LIST_ONLY);                         \
+}                                                                       \
+                                                                        \
+void greatest_get_report(struct greatest_report_t *report) {            \
+    if (report) {                                                       \
+        report->passed = greatest_info.passed;                          \
+        report->failed = greatest_info.failed;                          \
+        report->skipped = greatest_info.skipped;                        \
+        report->assertions = greatest_info.assertions;                  \
+    }                                                                   \
+}                                                                       \
+                                                                        \
+unsigned int greatest_get_verbosity(void) {                             \
+    return greatest_info.verbosity;                                     \
+}                                                                       \
+                                                                        \
+void greatest_set_verbosity(unsigned int verbosity) {                   \
+    greatest_info.verbosity = (unsigned char)verbosity;                 \
+}                                                                       \
+                                                                        \
+void greatest_set_flag(greatest_flag_t flag) {                          \
+    greatest_info.flags = (unsigned char)(greatest_info.flags | flag);  \
+}                                                                       \
+                                                                        \
+void greatest_set_test_suffix(const char *suffix) {                     \
+    greatest_info.name_suffix = suffix;                                 \
+}                                                                       \
+                                                                        \
+void GREATEST_SET_SETUP_CB(greatest_setup_cb *cb, void *udata) {        \
+    greatest_info.setup = cb;                                           \
+    greatest_info.setup_udata = udata;                                  \
+}                                                                       \
+                                                                        \
+void GREATEST_SET_TEARDOWN_CB(greatest_teardown_cb *cb, void *udata) {  \
+    greatest_info.teardown = cb;                                        \
+    greatest_info.teardown_udata = udata;                               \
+}                                                                       \
+                                                                        \
+static int greatest_string_equal_cb(const void *expd, const void *got,  \
+    void *udata) {                                                      \
+    size_t *size = (size_t *)udata;                                     \
+    return (size != NULL                                                \
+        ? (0 == strncmp((const char *)expd, (const char *)got, *size))  \
+        : (0 == strcmp((const char *)expd, (const char *)got)));        \
+}                                                                       \
+                                                                        \
+static int greatest_string_printf_cb(const void *t, void *udata) {      \
+    (void)udata; /* note: does not check \0 termination. */             \
+    return GREATEST_FPRINTF(GREATEST_STDOUT, "%s", (const char *)t);    \
+}                                                                       \
+                                                                        \
+greatest_type_info greatest_type_info_string = {                        \
+    greatest_string_equal_cb, greatest_string_printf_cb,                \
+};                                                                      \
+                                                                        \
+static int greatest_memory_equal_cb(const void *expd, const void *got,  \
+    void *udata) {                                                      \
+    greatest_memory_cmp_env *env = (greatest_memory_cmp_env *)udata;    \
+    return (0 == memcmp(expd, got, env->size));                         \
+}                                                                       \
+                                                                        \
+/* Hexdump raw memory, with differences highlighted */                  \
+static int greatest_memory_printf_cb(const void *t, void *udata) {      \
+    greatest_memory_cmp_env *env = (greatest_memory_cmp_env *)udata;    \
+    const unsigned char *buf = (const unsigned char *)t;                \
+    unsigned char diff_mark = ' ';                                      \
+    FILE *out = GREATEST_STDOUT;                                        \
+    size_t i, line_i, line_len = 0;                                     \
+    int len = 0;   /* format hexdump with differences highlighted */    \
+    for (i = 0; i < env->size; i+= line_len) {                          \
+        diff_mark = ' ';                                                \
+        line_len = env->size - i;                                       \
+        if (line_len > 16) { line_len = 16; }                           \
+        for (line_i = i; line_i < i + line_len; line_i++) {             \
+            if (env->exp[line_i] != env->got[line_i]) diff_mark = 'X';  \
+        }                                                               \
+        len += GREATEST_FPRINTF(out, "\n%04x %c ",                      \
+            (unsigned int)i, diff_mark);                                \
+        for (line_i = i; line_i < i + line_len; line_i++) {             \
+            int m = env->exp[line_i] == env->got[line_i]; /* match? */  \
+            len += GREATEST_FPRINTF(out, "%02x%c",                      \
+                buf[line_i], m ? ' ' : '<');                            \
+        }                                                               \
+        for (line_i = 0; line_i < 16 - line_len; line_i++) {            \
+            len += GREATEST_FPRINTF(out, "   ");                        \
+        }                                                               \
+        GREATEST_FPRINTF(out, " ");                                     \
+        for (line_i = i; line_i < i + line_len; line_i++) {             \
+            unsigned char c = buf[line_i];                              \
+            len += GREATEST_FPRINTF(out, "%c", isprint(c) ? c : '.');   \
+        }                                                               \
+    }                                                                   \
+    len += GREATEST_FPRINTF(out, "\n");                                 \
+    return len;                                                         \
+}                                                                       \
+                                                                        \
+void greatest_prng_init_first_pass(int id) {                            \
+    greatest_info.prng[id].random_order = 1;                            \
+    greatest_info.prng[id].count_run = 0;                               \
+}                                                                       \
+                                                                        \
+int greatest_prng_init_second_pass(int id, unsigned long seed) {        \
+    struct greatest_prng *p = &greatest_info.prng[id];                  \
+    if (p->count == 0) { return 0; }                                    \
+    p->count_ceil = p->count;                                           \
+    for (p->m = 1; p->m < p->count; p->m <<= 1) {}                      \
+    p->state = seed & 0x1fffffff;     /* only use lower 29 bits */      \
+    p->a = 4LU * p->state;            /* to avoid overflow when */      \
+    p->a = (p->a ? p->a : 4) | 1;            /* multiplied by 4 */      \
+    p->c = 2147483647;        /* and so p->c ((2 ** 31) - 1) is */      \
+    p->initialized = 1;     /* always relatively prime to p->a. */      \
+    fprintf(stderr, "init_second_pass: a %lu, c %lu, state %lu\n",      \
+        p->a, p->c, p->state);                                          \
+    return 1;                                                           \
+}                                                                       \
+                                                                        \
+/* Step the pseudorandom number generator until its state reaches       \
+ * another test ID between 0 and the test count.                        \
+ * This use a linear congruential pseudorandom number generator,        \
+ * with the power-of-two ceiling of the test count as the modulus, the  \
+ * masked seed as the multiplier, and a prime as the increment. For     \
+ * each generated value < the test count, run the corresponding test.   \
+ * This will visit all IDs 0 <= X < mod once before repeating,          \
+ * with a starting position chosen based on the initial seed.           \
+ * For details, see: Knuth, The Art of Computer Programming             \
+ * Volume. 2, section 3.2.1. */                                         \
+void greatest_prng_step(int id) {                                       \
+    struct greatest_prng *p = &greatest_info.prng[id];                  \
+    do {                                                                \
+        p->state = ((p->a * p->state) + p->c) & (p->m - 1);             \
+    } while (p->state >= p->count_ceil);                                \
+}                                                                       \
+                                                                        \
+void GREATEST_INIT(void) {                                              \
+    /* Suppress unused function warning if features aren't used */      \
+    (void)greatest_run_suite;                                           \
+    (void)greatest_parse_options;                                       \
+    (void)greatest_prng_step;                                           \
+    (void)greatest_prng_init_first_pass;                                \
+    (void)greatest_prng_init_second_pass;                               \
+    (void)greatest_set_test_suffix;                                     \
+                                                                        \
+    memset(&greatest_info, 0, sizeof(greatest_info));                   \
+    greatest_info.width = GREATEST_DEFAULT_WIDTH;                       \
+    GREATEST_SET_TIME(greatest_info.begin);                             \
+}                                                                       \
+                                                                        \
+/* Report passes, failures, skipped tests, the number of                \
+ * assertions, and the overall run time. */                             \
+void GREATEST_PRINT_REPORT(void) {                                      \
+    if (!GREATEST_LIST_ONLY()) {                                        \
+        update_counts_and_reset_suite();                                \
+        GREATEST_SET_TIME(greatest_info.end);                           \
+        GREATEST_FPRINTF(GREATEST_STDOUT,                               \
+            "\nTotal: %u test%s",                                       \
+            greatest_info.tests_run,                                    \
+            greatest_info.tests_run == 1 ? "" : "s");                   \
+        GREATEST_CLOCK_DIFF(greatest_info.begin,                        \
+            greatest_info.end);                                         \
+        GREATEST_FPRINTF(GREATEST_STDOUT, ", %u assertion%s\n",         \
+            greatest_info.assertions,                                   \
+            greatest_info.assertions == 1 ? "" : "s");                  \
+        GREATEST_FPRINTF(GREATEST_STDOUT,                               \
+            "Pass: %u, fail: %u, skip: %u.\n",                          \
+            greatest_info.passed,                                       \
+            greatest_info.failed, greatest_info.skipped);               \
+    }                                                                   \
+}                                                                       \
+                                                                        \
+greatest_type_info greatest_type_info_memory = {                        \
+    greatest_memory_equal_cb, greatest_memory_printf_cb,                \
+};                                                                      \
+                                                                        \
+greatest_run_info greatest_info
+
+/* Handle command-line arguments, etc. */
+#define GREATEST_MAIN_BEGIN()                                           \
+    do {                                                                \
+        GREATEST_INIT();                                                \
+        greatest_parse_options(argc, argv);                             \
+    } while (0)
+
+/* Report results, exit with exit status based on results. */
+#define GREATEST_MAIN_END()                                             \
+    do {                                                                \
+        GREATEST_PRINT_REPORT();                                        \
+        return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);   \
+    } while (0)
+
+/* Make abbreviations without the GREATEST_ prefix for the
+ * most commonly used symbols. */
+#if GREATEST_USE_ABBREVS
+#define TEST           GREATEST_TEST
+#define SUITE          GREATEST_SUITE
+#define SUITE_EXTERN   GREATEST_SUITE_EXTERN
+#define RUN_TEST       GREATEST_RUN_TEST
+#define RUN_TEST1      GREATEST_RUN_TEST1
+#define RUN_SUITE      GREATEST_RUN_SUITE
+#define IGNORE_TEST    GREATEST_IGNORE_TEST
+#define ASSERT         GREATEST_ASSERT
+#define ASSERTm        GREATEST_ASSERTm
+#define ASSERT_FALSE   GREATEST_ASSERT_FALSE
+#define ASSERT_EQ      GREATEST_ASSERT_EQ
+#define ASSERT_NEQ     GREATEST_ASSERT_NEQ
+#define ASSERT_GT      GREATEST_ASSERT_GT
+#define ASSERT_GTE     GREATEST_ASSERT_GTE
+#define ASSERT_LT      GREATEST_ASSERT_LT
+#define ASSERT_LTE     GREATEST_ASSERT_LTE
+#define ASSERT_EQ_FMT  GREATEST_ASSERT_EQ_FMT
+#define ASSERT_IN_RANGE GREATEST_ASSERT_IN_RANGE
+#define ASSERT_EQUAL_T GREATEST_ASSERT_EQUAL_T
+#define ASSERT_STR_EQ  GREATEST_ASSERT_STR_EQ
+#define ASSERT_STRN_EQ GREATEST_ASSERT_STRN_EQ
+#define ASSERT_MEM_EQ  GREATEST_ASSERT_MEM_EQ
+#define ASSERT_ENUM_EQ GREATEST_ASSERT_ENUM_EQ
+#define ASSERT_FALSEm  GREATEST_ASSERT_FALSEm
+#define ASSERT_EQm     GREATEST_ASSERT_EQm
+#define ASSERT_NEQm    GREATEST_ASSERT_NEQm
+#define ASSERT_GTm     GREATEST_ASSERT_GTm
+#define ASSERT_GTEm    GREATEST_ASSERT_GTEm
+#define ASSERT_LTm     GREATEST_ASSERT_LTm
+#define ASSERT_LTEm    GREATEST_ASSERT_LTEm
+#define ASSERT_EQ_FMTm GREATEST_ASSERT_EQ_FMTm
+#define ASSERT_IN_RANGEm GREATEST_ASSERT_IN_RANGEm
+#define ASSERT_EQUAL_Tm GREATEST_ASSERT_EQUAL_Tm
+#define ASSERT_STR_EQm GREATEST_ASSERT_STR_EQm
+#define ASSERT_STRN_EQm GREATEST_ASSERT_STRN_EQm
+#define ASSERT_MEM_EQm GREATEST_ASSERT_MEM_EQm
+#define ASSERT_ENUM_EQm GREATEST_ASSERT_ENUM_EQm
+#define PASS           GREATEST_PASS
+#define FAIL           GREATEST_FAIL
+#define SKIP           GREATEST_SKIP
+#define PASSm          GREATEST_PASSm
+#define FAILm          GREATEST_FAILm
+#define SKIPm          GREATEST_SKIPm
+#define SET_SETUP      GREATEST_SET_SETUP_CB
+#define SET_TEARDOWN   GREATEST_SET_TEARDOWN_CB
+#define CHECK_CALL     GREATEST_CHECK_CALL
+#define SHUFFLE_TESTS  GREATEST_SHUFFLE_TESTS
+#define SHUFFLE_SUITES GREATEST_SHUFFLE_SUITES
+
+#ifdef GREATEST_VA_ARGS
+#define RUN_TESTp      GREATEST_RUN_TESTp
+#endif
+
+#if GREATEST_USE_LONGJMP
+#define ASSERT_OR_LONGJMP  GREATEST_ASSERT_OR_LONGJMP
+#define ASSERT_OR_LONGJMPm GREATEST_ASSERT_OR_LONGJMPm
+#define FAIL_WITH_LONGJMP  GREATEST_FAIL_WITH_LONGJMP
+#define FAIL_WITH_LONGJMPm GREATEST_FAIL_WITH_LONGJMPm
+#endif
+
+#endif /* USE_ABBREVS */
+
+#if defined(__cplusplus) && !defined(GREATEST_NO_EXTERN_CPLUSPLUS)
+}
+#endif
+
+#endif

--- a/module.nix
+++ b/module.nix
@@ -51,6 +51,7 @@ with lib; let
     SMOOTH = cfg.parameters.smooth;
     MOTIVITY = cfg.parameters.motivity;
     SYNC_SPEED = cfg.parameters.syncSpeed;
+    GAIN = cfg.parameters.gain;
   };
 
   # Generate modprobe parameter string
@@ -59,6 +60,8 @@ with lib; let
     formatParam = name: value:
       if name == "MODE"
       then "${name}=${toString (modeMap.${value})}"
+      else if name == "GAIN"
+      then "${name}=${toString (toFixedPoint (if value then 1.0 else 0.0))}"
       else "${name}=${toString (toFixedPoint value)}";
   in
     concatStringsSep " " (mapAttrsToList formatParam validParams);
@@ -237,6 +240,12 @@ in {
             // {description = "positive float";});
         default = null;
         description = "Sets the middle sensitivity between min and max sensitivity. Must be positive.";
+      };
+
+      gain = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Interpret the Synchronous curve as gain instead of sensitivity.";
       };
     };
   };

--- a/module.nix
+++ b/module.nix
@@ -26,6 +26,7 @@ with lib; let
     natural = 1;
     synchronous = 2;
     no_accel = 3;
+    synchronous-gain = 4;
   };
 
   # Parameter mapping (from driver/params.h)
@@ -51,7 +52,12 @@ with lib; let
     SMOOTH = cfg.parameters.smooth;
     MOTIVITY = cfg.parameters.motivity;
     SYNC_SPEED = cfg.parameters.syncSpeed;
-    GAIN = cfg.parameters.gain;
+
+    # Synchronous Gain mode parameters
+    SYNC_GAIN_GAMMA = cfg.parameters.syncGainGamma;
+    SYNC_GAIN_SMOOTH = cfg.parameters.syncGainSmooth;
+    SYNC_GAIN_MOTIVITY = cfg.parameters.syncGainMotivity;
+    SYNC_GAIN_SPEED = cfg.parameters.syncGainSpeed;
   };
 
   # Generate modprobe parameter string
@@ -60,8 +66,6 @@ with lib; let
     formatParam = name: value:
       if name == "MODE"
       then "${name}=${toString (modeMap.${value})}"
-      else if name == "GAIN"
-      then "${name}=${toString (toFixedPoint (if value then 1.0 else 0.0))}"
       else "${name}=${toString (toFixedPoint value)}";
   in
     concatStringsSep " " (mapAttrsToList formatParam validParams);
@@ -166,7 +170,7 @@ in {
       };
 
       mode = mkOption {
-        type = types.nullOr (types.enum ["linear" "natural" "synchronous" "no_accel"]);
+        type = types.nullOr (types.enum ["linear" "natural" "synchronous" "no_accel" "synchronous-gain"]);
         default = null;
         description = "Acceleration mode.";
       };
@@ -242,11 +246,39 @@ in {
         description = "Sets the middle sensitivity between min and max sensitivity. Must be positive.";
       };
 
-      gain = mkOption {
-        type = types.nullOr types.bool;
+      # Synchronous Gain mode parameters
+      syncGainGamma = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 0.0)
+            // {description = "positive float";});
         default = null;
-        description = "Interpret the Synchronous curve as gain instead of sensitivity.";
+        description = "Controls how fast Synchronous Gain changes around its midpoint.";
       };
+
+      syncGainSmooth = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x >= 0.0 && x <= 1.0)
+            // {description = "float between 0.0 and 1.0";});
+        default = null;
+        description = "Controls the suddenness of the Synchronous Gain increase.";
+      };
+
+      syncGainMotivity = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 1.0)
+            // {description = "float > 1.0";});
+        default = null;
+        description = "Sets the Synchronous Gain maximum and reciprocal minimum.";
+      };
+
+      syncGainSpeed = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x > 0.0)
+            // {description = "positive float";});
+        default = null;
+        description = "Sets the midpoint speed for Synchronous Gain.";
+      };
+
     };
   };
 

--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -4,6 +4,7 @@ use maccel_core::ALL_LINEAR_PARAMS;
 use maccel_core::ALL_MODES;
 use maccel_core::ALL_NATURAL_PARAMS;
 use maccel_core::ALL_NOACCEL_PARAMS;
+use maccel_core::ALL_SYNCHRONOUS_GAIN_PARAMS;
 use maccel_core::ALL_SYNCHRONOUS_PARAMS;
 use maccel_core::Param;
 use maccel_core::get_param_value_from_ctx;
@@ -106,6 +107,20 @@ impl App {
                                 f64::from(get_param_value_from_ctx!(ctx, SensMult)) * 2.0; // No other factor, sens is 1.0
 
                             [0.0, upper_bound.max(1.0)] // Ensure at least a small visible range
+                        }),
+                    ),
+                ),
+                Screen::new(
+                    AccelMode::SynchronousGain,
+                    collect_inputs_for_params(ALL_SYNCHRONOUS_GAIN_PARAMS, context.clone()),
+                    Box::new(
+                        SensitivityGraph::new(context.clone()).on_y_axix_bounds_update(|ctx| {
+                            let upper_bound = f64::from(get_param_value_from_ctx!(ctx, SensMult))
+                                * f64::from(get_param_value_from_ctx!(ctx, SyncGainMotivity))
+                                    .max(1.0)
+                                * 2.0;
+
+                            [0.0, upper_bound]
                         }),
                     ),
                 ),

--- a/tui/src/param_input.rs
+++ b/tui/src/param_input.rs
@@ -5,8 +5,8 @@ use maccel_core::persist::ParamStore;
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::Rect;
 use ratatui::{prelude::*, widgets::*};
-use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
+use tui_input::backend::crossterm::EventHandler;
 
 use crate::action::{Action, Actions, InputAction};
 use crate::component::TuiComponent;

--- a/tui/src/screen.rs
+++ b/tui/src/screen.rs
@@ -301,7 +301,7 @@ impl<PS: ParamStore + Debug> TuiComponent for Screen<PS> {
 
 #[cfg(test)]
 mod test {
-    use maccel_core::{persist::ParamStore, AccelMode};
+    use maccel_core::{AccelMode, persist::ParamStore};
 
     use crossterm::event::KeyCode;
 


### PR DESCRIPTION
Closes #78.

## Summary

- add `synchronous-gain` as a distinct acceleration mode while preserving all existing mode ordinals
- keep legacy Synchronous and Synchronous Gain in independent code modules with separate argument types and implementations
- give the gain mode independent `SYNC_GAIN_GAMMA`, `SYNC_GAIN_SMOOTH`, `SYNC_GAIN_MOTIVITY`, and `SYNC_GAIN_SPEED` parameters
- port Raw Accel's integrated-velocity lookup math with 97 logarithmically spaced points and two integration partitions per interval
- rebuild the gain lookup table only when Synchronous Gain parameters change, outside the mouse-event hot path
- expose a dedicated Synchronous Gain screen through the CLI, TUI, and NixOS module

## Implementation

- [x] Add a separate driver and Rust mode with stable ordinal `4`
- [x] Remove the `GAIN` boolean and its runtime branch
- [x] Split `synchronous.h` and `synchronous_gain.h` into independent implementations
- [x] Add independent `SYNC_GAIN_*` configuration
- [x] Match Raw Accel's interpolation and boundary behavior
- [x] Publish parameter updates safely under concurrent input handling
- [x] Preserve the existing legacy Synchronous snapshot and configuration
- [x] Add Raw Accel parity, mode-dispatch, ordinal, and parameter-name tests
- [x] Document CLI and NixOS configuration
- [ ] Exercise the installed module and mouse flow on a test machine

## Verification

- `make test`
- `make test name=synchronous_gain DRIVER_CFLAGS=-DFIXEDPT_BITS=32`
- `make build`
- `cargo test --all`
- `cargo fmt --all --check`
- `clang-format --dry-run --Werror driver/accel.h driver/accel/synchronous.h driver/accel/synchronous_gain.h driver/accel/mode.h driver/accel_k.h driver/maccel.c driver/params.h driver/tests/synchronous_gain.test.c`

Nix parsing was not run locally because Nix is not installed in the development environment; release tags remain intentionally deferred while the PR is a draft.