### PR TITLE
Expose default Nix package

### DIFF
--- a/README_NIXOS.md
+++ b/README_NIXOS.md
@@ -12,6 +12,15 @@ If you're on NixOS, maccel provides a declarative flake module to seamlessly int
 
 ## Quick Start
 
+To install only the CLI and TUI in a Nix profile:
+
+```sh
+nix profile add github:Gnarus-G/maccel
+```
+
+The profile package does not install the kernel module; use the NixOS module
+below for the complete driver installation.
+
 Add to your `flake.nix` inputs:
 
 ```nix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,44 @@
 {
-  description = "maccel NixOS Module";
+  description = "maccel mouse acceleration driver and CLI";
 
-  outputs = {...}: {
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {inherit system;};
+    moduleEvaluation = nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        self.nixosModules.default
+        {
+          hardware.maccel = {
+            enable = true;
+            enableCli = true;
+          };
+          system.stateVersion = "24.11";
+        }
+      ];
+    };
+  in {
+    packages.${system} = {
+      maccel-cli = pkgs.callPackage ./package.nix {};
+      default = self.packages.${system}.maccel-cli;
+    };
+    checks.${system} = {
+      default = self.packages.${system}.default;
+      nixos-module = let
+        installedPackages = map nixpkgs.lib.getName moduleEvaluation.config.environment.systemPackages;
+      in
+        assert builtins.elem "maccel-cli" installedPackages;
+          pkgs.runCommand "maccel-module-check" {} ''
+            touch $out
+          '';
+    };
+
     nixosModules.default = import ./module.nix;
   };
 }

--- a/module.nix
+++ b/module.nix
@@ -12,10 +12,6 @@ with lib; let
   pkgbuildContent = builtins.readFile ./PKGBUILD;
   kernelModuleVersion = builtins.head (builtins.match ".*pkgver=([^[:space:]]+).*" pkgbuildContent);
 
-  # Extract version from cli/Cargo.toml
-  cliCargoToml = builtins.fromTOML (builtins.readFile ./cli/Cargo.toml);
-  cliVersion = cliCargoToml.package.version;
-
   # Convert float to fixed-point integer (64-bit, 32 fractional bits)
   fixedPointScale = 4294967296; # 2^32
   toFixedPoint = value: builtins.floor (value * fixedPointScale + 0.5);
@@ -101,23 +97,7 @@ with lib; let
     }) {};
 
   # Optional CLI tools
-  maccel-cli = pkgs.rustPlatform.buildRustPackage rec {
-    pname = "maccel-cli";
-    version = cliVersion;
-
-    src = ./.;
-
-    cargoLock.lockFile = "${src}/Cargo.lock";
-
-    cargoBuildFlags = ["--bin" "maccel"];
-
-    meta = with lib; {
-      description = "CLI and TUI tools for configuring maccel.";
-      homepage = "https://www.maccel.org/";
-      license = licenses.gpl2Plus;
-      platforms = platforms.linux;
-    };
-  };
+  maccel-cli = pkgs.callPackage ./package.nix {};
 in {
   options.hardware.maccel = {
     enable = mkEnableOption "Enable maccel mouse acceleration driver (kernel module). Parameters must be configured via `hardware.maccel.parameters`.";

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  rustPlatform,
+}:
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ./cli/Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = "maccel-cli";
+  version = cargoToml.package.version;
+
+  src = lib.cleanSource ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+  cargoBuildFlags = ["--bin" "maccel"];
+
+  meta = {
+    description = "CLI and TUI tools for configuring maccel";
+    homepage = "https://www.maccel.org/";
+    license = lib.licenses.gpl2Plus;
+    platforms = ["x86_64-linux"];
+    mainProgram = "maccel";
+  };
+}


### PR DESCRIPTION
## Summary
- expose the CLI as `packages.x86_64-linux.default`
- reuse one package derivation from the flake and NixOS module
- lock nixpkgs and document profile installation
- check both the package and enabled module configuration

## Verification
- `nix flake check path:/tmp/maccel` in `nixos/nix:latest`

Fixes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nix packaging for the `maccel` CLI/TUI.
  * Added a default Nix package and NixOS module support for installing the CLI.
  * Added validation checks for the packaged CLI and NixOS configuration.

* **Documentation**
  * Added Quick Start instructions for installing the CLI with `nix profile add`.
  * Clarified that CLI installation does not include the kernel module; complete driver setup requires the NixOS module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->