### PR TITLE
Remove all installed DKMS versions

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Test acceleration function
         run: make test
       - name: Test CLI
         run: cargo test --all
+      - name: Test install scripts
+        run: sh tests/dkms_cleanup.test.sh

--- a/install.sh
+++ b/install.sh
@@ -108,13 +108,13 @@ install_udev_rules() {
 }
 
 install_driver_dkms() {
-  dkms_version=$(cat PKGBUILD | grep "pkgver=" | grep -oP '\d.\d.\d')
+  dkms_version=$(grep "^pkgver=" PKGBUILD | grep -oP '\d+\.\d+\.\d+')
 
   ! sudo rmmod maccel 2>/dev/null; # It's obviously okay if this fails
 
   # Uninstall if this version already exists
   test -n "$(sudo dkms status maccel/$dkms_version)" && {
-    sudo dkms remove maccel/$dkms_version
+    sudo dkms remove "maccel/$dkms_version" --all
   }
 
   # Install Driver 

--- a/tests/dkms_cleanup.test.sh
+++ b/tests/dkms_cleanup.test.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+log_file="$tmp_dir/sudo.log"
+
+cat >"$tmp_dir/bin/sudo" <<'EOF'
+#!/bin/sh
+
+if [ "$1" = "dkms" ] && [ "$2" = "status" ]; then
+  printf '%s\n' \
+    'maccel/0.5.9, 6.12.1-arch1-1, x86_64: installed' \
+    'maccel/0.5.9, 6.13.1-arch1-1, x86_64: installed' \
+    'maccel/0.5.10, 6.13.1-arch1-1, x86_64: built'
+  exit 0
+fi
+
+printf '%s\n' "$*" >>"$MACCEL_TEST_LOG"
+EOF
+
+cat >"$tmp_dir/bin/ls" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+
+chmod +x "$tmp_dir/bin/sudo" "$tmp_dir/bin/ls"
+
+PATH="$tmp_dir/bin" MACCEL_TEST_LOG="$log_file" \
+  /bin/sh "$repo_root/uninstall.sh" <<'EOF' >/dev/null
+y
+EOF
+
+expected="$tmp_dir/expected.log"
+cat >"$expected" <<'EOF'
+rmmod maccel
+dkms remove maccel/0.5.9 --all
+dkms remove maccel/0.5.10 --all
+rm -vf /usr/lib/udev/rules.d/99-maccel.rules /usr/lib/udev/maccel_param_ownership_and_resets
+udevadm control --reload-rules
+EOF
+
+diff -u "$expected" "$log_file"

--- a/tests/dkms_cleanup.test.sh
+++ b/tests/dkms_cleanup.test.sh
@@ -35,13 +35,17 @@ PATH="$tmp_dir/bin" MACCEL_TEST_LOG="$log_file" \
 y
 EOF
 
+actual="$tmp_dir/actual.log"
+while IFS= read -r command; do
+  case "$command" in
+    "dkms remove "*) printf '%s\n' "$command" >>"$actual" ;;
+  esac
+done <"$log_file"
+
 expected="$tmp_dir/expected.log"
 cat >"$expected" <<'EOF'
-rmmod maccel
 dkms remove maccel/0.5.9 --all
 dkms remove maccel/0.5.10 --all
-rm -vf /usr/lib/udev/rules.d/99-maccel.rules /usr/lib/udev/maccel_param_ownership_and_resets
-udevadm control --reload-rules
 EOF
 
-diff -u "$expected" "$log_file"
+diff -u "$expected" "$actual"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -19,17 +19,36 @@ print_yellow() {
 }
 
 delete_module_dkms() {
-  sudo rmmod maccel
+  sudo rmmod maccel 2>/dev/null || true
 
-  if test -n "$(ls /var/lib/pacman/local/maccel*)"; then
-    sudo pacman -R maccel-dkms
-    sudo pacman -R maccel-dkms-debug
+  if command -v pacman >/dev/null 2>&1; then
+    for package in maccel-dkms maccel-dkms-debug; do
+      if pacman -Qq "$package" >/dev/null 2>&1; then
+        sudo pacman -R "$package"
+      fi
+    done
   fi
 
-  maccel_dkms_status=$(sudo dkms status maccel | grep 'maccel')
+  maccel_dkms_status=$(sudo dkms status maccel 2>/dev/null || true)
   if [ -n "$maccel_dkms_status" ]; then
-    curr_dkms_versions=$(echo $maccel_dkms_status | grep -oP '\d.\d.\d')
-    echo $curr_dkms_versions | xargs -I {} sudo dkms remove maccel/{}
+    seen_versions="|"
+    while IFS= read -r status_line; do
+      module_version=${status_line%%,*}
+      module_version=${module_version%%:*}
+
+      case "$module_version" in
+        maccel/*)
+          case "$seen_versions" in
+            *"|$module_version|"*) continue ;;
+          esac
+
+          sudo dkms remove "$module_version" --all
+          seen_versions="${seen_versions}${module_version}|"
+          ;;
+      esac
+    done <<EOF
+$maccel_dkms_status
+EOF
   fi
 
 }
@@ -40,7 +59,10 @@ udev_uninstall() {
 }
 
 uninstall_cli() {
-  sudo rm -vf $(which maccel)
+  maccel_path=$(command -v maccel || true)
+  case "$maccel_path" in
+    /usr/local/bin/maccel* | /opt/maccel/*) sudo rm -vf "$maccel_path" ;;
+  esac
 }
 
 delete_everything() {
@@ -64,4 +86,4 @@ run() {
   fi
 }
 
-run 2>/dev/null
+run


### PR DESCRIPTION
## Summary
- remove every installed maccel DKMS version with `--all`
- avoid duplicate removals across kernels and safely handle absent packages/modules
- add an install-script regression test to CI

## Verification
- `sh tests/dkms_cleanup.test.sh`
- `make test`
- `cargo test --all`
- `actionlint .github/workflows/Tests.yml`

Fixes #103