### PR TITLE
Add angle snapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "maccel-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cc",

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=maccel-dkms
 _pkgname="maccel"
-pkgver=0.5.9
+pkgver=0.6.0
 pkgrel=1
 pkgdesc="Mouse acceleration driver and kernel module for Linux."
 arch=("x86_64")

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ maccel set angle-rotation 15   # rotate input 15 degrees
 maccel set angle-rotation 0    # disable rotation (default)
 ```
 
+## Angle Snapping
+
+Angle snapping projects movement near the horizontal or vertical axis exactly
+onto that axis while preserving its magnitude; values range from `0` (disabled)
+to `45` degrees, and snapping is applied after rotation.
+
+```sh
+maccel set param angle-snap 10
+maccel set param angle-snap 0  # disable snapping (default)
+```
+
 ### Known limitation
 
 When the mouse moves along a single axis (purely horizontal or vertical), some mice and kernel versions only report one `EV_REL` event (`REL_X` or `REL_Y`) instead of both. The rotation transform produces a cross-axis component that needs to be injected as a synthetic event.

--- a/README_NIXOS.md
+++ b/README_NIXOS.md
@@ -36,6 +36,7 @@ Create your `maccel.nix` module:
       yxRatio = 1.0;
       inputDpi = 1000.0;
       angleRotation = 0.0;
+      angleSnap = 0.0;
       mode = "synchronous";
 
       # Linear mode

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maccel-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [[bin]]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,18 @@ struct Cli {
     command: Option<CLiCommands>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn common_bulk_set_keeps_angle_snap_optional() {
+        let cli = Cli::try_parse_from(["maccel", "set", "all", "common", "1", "1", "1000", "0"]);
+
+        assert!(cli.is_ok());
+    }
+}
+
 #[derive(clap::Subcommand, Default)]
 enum CLiCommands {
     /// Open the Terminal UI to manage the parameters

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -103,6 +103,7 @@ impl<PS: ParamStore> TuiContext<PS> {
             motivity: get!(Motivity),
             sync_speed: get!(SyncSpeed),
             angle_rotation: get!(AngleRotation),
+            angle_snap: get!(AngleSnap),
         }
     }
 }

--- a/crates/core/src/params.rs
+++ b/crates/core/src/params.rs
@@ -46,14 +46,22 @@ macro_rules! make_curve_params_struct {
 }
 
 macro_rules! declare_params {
-    ( Common { $($common_param:tt),+$(,)? } , $( $mode:tt { $($param:tt),*$(,)? }, )+) => {
+    (
+        Common { $($common_param:tt),+$(,)? },
+        OptionalCommon { $($optional_common_param:tt),+$(,)? },
+        $( $mode:tt { $($param:tt),*$(,)? }, )+
+    ) => {
         declare_common_params! {
             $( $common_param, )+
+            $( $optional_common_param, )+
             $( $( $param, )* )+
         }
 
         /// Array of all the common parameters for convenience.
-        pub const ALL_COMMON_PARAMS: &[Param] = &[ $( Param::$common_param),+ ];
+        pub const ALL_COMMON_PARAMS: &[Param] = &[
+            $( Param::$common_param, )+
+            $( Param::$optional_common_param ),+
+        ];
 
 
         #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
@@ -72,6 +80,7 @@ macro_rules! declare_params {
             #[repr(C)]
             pub struct AccelParams {
                 $( pub [< $common_param:snake:lower >] : Fpt, )+
+                $( pub [< $optional_common_param:snake:lower >] : Fpt, )+
                 pub by_mode: AccelParamsByMode,
             }
 
@@ -88,7 +97,8 @@ macro_rules! declare_params {
             #[cfg_attr(feature = "clap", derive(clap::Args))]
             #[derive(Debug, Clone, Copy, PartialEq)]
             pub struct CommonParamArgs {
-                $( pub [< $common_param:snake:lower >]: f64 ),+
+                $( pub [< $common_param:snake:lower >]: f64, )+
+                $( pub [< $optional_common_param:snake:lower >]: Option<f64> ),+
             }
         }
 
@@ -176,6 +186,7 @@ declare_params!(
         InputDpi,
         AngleRotation
     },
+    OptionalCommon { AngleSnap },
     Linear {
         Accel,
         OffsetLinear,
@@ -233,6 +244,7 @@ impl Param {
             Param::Motivity => "MOTIVITY",
             Param::SyncSpeed => "SYNC_SPEED",
             Param::AngleRotation => "ANGLE_ROTATION",
+            Param::AngleSnap => "ANGLE_SNAP",
         }
     }
 
@@ -252,6 +264,7 @@ impl Param {
             Param::Motivity => "Motivity",
             Param::SyncSpeed => "Sync Speed",
             Param::AngleRotation => "Angle Rotation",
+            Param::AngleSnap => "Angle Snap",
         }
     }
 
@@ -265,6 +278,9 @@ impl Param {
                 "Mouse DPI. Used to normalize to 1000 DPI equivalent for consistent acceleration."
             }
             Param::AngleRotation => "Rotation angle in degrees for sensitivity direction.",
+            Param::AngleSnap => {
+                "Snap movement to the nearest horizontal or vertical axis within 0-45 degrees."
+            }
             Param::Accel => "Acceleration strength. Higher values = faster cursor at high speeds.",
             Param::OffsetLinear => "Speed threshold (counts/ms) before acceleration begins.",
             Param::OutputCap => "Maximum sensitivity multiplier cap. Prevents excessive speed.",
@@ -306,6 +322,15 @@ fn format_param_value_works() {
     assert_eq!(format_param_value(0.055000), "0.055");
 }
 
+#[cfg(test)]
+#[test]
+fn angle_snap_must_be_between_zero_and_forty_five_degrees() {
+    assert!(validate_param_value(Param::AngleSnap, 0.0).is_ok());
+    assert!(validate_param_value(Param::AngleSnap, 45.0).is_ok());
+    assert!(validate_param_value(Param::AngleSnap, -0.1).is_err());
+    assert!(validate_param_value(Param::AngleSnap, 45.1).is_err());
+}
+
 pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Result<()> {
     match param_tag {
         Param::SensMult => {}
@@ -316,6 +341,11 @@ pub(crate) fn validate_param_value(param_tag: Param, value: f64) -> anyhow::Resu
             }
         }
         Param::AngleRotation => {}
+        Param::AngleSnap => {
+            if !(0.0..=45.0).contains(&value) {
+                anyhow::bail!("Angle snap must be between 0 and 45 degrees");
+            }
+        }
         Param::Accel => {}
         Param::OutputCap => {}
         Param::OffsetLinear | Param::OffsetNatural => {

--- a/crates/core/src/persist.rs
+++ b/crates/core/src/persist.rs
@@ -78,12 +78,16 @@ impl SysFsStore {
             yx_ratio,
             input_dpi,
             angle_rotation,
+            angle_snap,
         } = args;
 
         self.set(Param::SensMult, sens_mult)?;
         self.set(Param::YxRatio, yx_ratio)?;
         self.set(Param::InputDpi, input_dpi)?;
         self.set(Param::AngleRotation, angle_rotation)?;
+        if let Some(angle_snap) = angle_snap {
+            self.set(Param::AngleSnap, angle_snap)?;
+        }
 
         Ok(())
     }

--- a/crates/core/src/sens_fns.rs
+++ b/crates/core/src/sens_fns.rs
@@ -35,6 +35,7 @@ impl AllParamArgs {
             yx_ratio: self.yx_ratio,
             input_dpi: self.input_dpi,
             angle_rotation: self.angle_rotation,
+            angle_snap: self.angle_snap,
             by_mode: params_by_mode,
         }
     }

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -24,6 +24,7 @@ struct accel_args {
   fpt yx_ratio;
   fpt input_dpi;
   fpt angle_rotation_deg;
+  fpt angle_snap_threshold;
 
   enum accel_mode tag;
   union __accel_args args;
@@ -66,6 +67,27 @@ static inline struct vector sensitivity(fpt input_speed,
 
 const fpt DEG_TO_RAD_FACTOR = fpt_xdiv(FIXEDPT_PI, fpt_rconst(180));
 
+static inline fpt snap_threshold(fpt degrees) {
+  return fpt_tan(fpt_mul(degrees, DEG_TO_RAD_FACTOR));
+}
+
+static inline struct vector snap_to_axis(struct vector input, fpt threshold) {
+  fpt abs_x = fpt_abs(input.x);
+  fpt abs_y = fpt_abs(input.y);
+
+  if (abs_x < fpt_mul(abs_y, threshold)) {
+    fpt length = scaled_magnitude(input);
+    return (struct vector){0, input.y < 0 ? -length : length};
+  }
+
+  if (abs_y < fpt_mul(abs_x, threshold)) {
+    fpt length = scaled_magnitude(input);
+    return (struct vector){input.x < 0 ? -length : length, 0};
+  }
+
+  return input;
+}
+
 static inline void f_accelerate(int *x, int *y, fpt time_interval_ms,
                                 struct accel_args args) {
   static fpt carry_x = 0;
@@ -74,10 +96,7 @@ static inline void f_accelerate(int *x, int *y, fpt time_interval_ms,
   fpt dx = fpt_fromint(*x);
   fpt dy = fpt_fromint(*y);
 
-  {
-    if (args.angle_rotation_deg == 0) {
-      goto accel_routine;
-    }
+  if (args.angle_rotation_deg != 0) {
     // Add rotation of input vector
     fpt degrees = args.angle_rotation_deg;
     fpt radians =
@@ -101,7 +120,20 @@ static inline void f_accelerate(int *x, int *y, fpt time_interval_ms,
     dx = dx_rot;
     dy = dy_rot;
   }
-accel_routine:
+
+  if (args.angle_snap_threshold > 0) {
+    struct vector snapped =
+        snap_to_axis((struct vector){dx, dy}, args.angle_snap_threshold);
+    dx = snapped.x;
+    dy = snapped.y;
+
+    if (dx == 0) {
+      carry_x = 0;
+    }
+    if (dy == 0) {
+      carry_y = 0;
+    }
+  }
 
   dbg("in                        (%d, %d)", *x, *y);
   dbg("in: x (fpt conversion) %s", fptoa(dx));
@@ -112,7 +144,13 @@ accel_routine:
   dx = fpt_mul(dx, dpi_factor);
   dy = fpt_mul(dy, dpi_factor);
 
-  fpt speed_in = input_speed(dx, dy, time_interval_ms);
+  fpt speed_in;
+  if (args.angle_snap_threshold > 0 && (dx == 0 || dy == 0)) {
+    fpt distance = dx == 0 ? fpt_abs(dy) : fpt_abs(dx);
+    speed_in = input_speed_from_distance(distance, time_interval_ms);
+  } else {
+    speed_in = input_speed(dx, dy, time_interval_ms);
+  }
   struct vector sens = sensitivity(speed_in, args);
   dbg("scale x                    %s", fptoa(sens.x));
   dbg("scale y                    %s", fptoa(sens.y));

--- a/driver/accel_k.h
+++ b/driver/accel_k.h
@@ -19,6 +19,7 @@ static struct accel_args collect_args(void) {
   accel.yx_ratio = atofp(PARAM_YX_RATIO);
   accel.input_dpi = atofp(PARAM_INPUT_DPI);
   accel.angle_rotation_deg = atofp(PARAM_ANGLE_ROTATION);
+  accel.angle_snap_threshold = PARAM_ANGLE_SNAP_THRESHOLD;
 
   switch (mode) {
   case synchronous: {

--- a/driver/math.h
+++ b/driver/math.h
@@ -20,6 +20,25 @@ static inline fpt magnitude(struct vector v) {
   return fpt_sqrt(x_square_plus_y_square);
 }
 
+static inline fpt scaled_magnitude(struct vector v) {
+  fpt abs_x = fpt_abs(v.x);
+  fpt abs_y = fpt_abs(v.y);
+  fpt larger = abs_x > abs_y ? abs_x : abs_y;
+  fpt smaller = abs_x > abs_y ? abs_y : abs_x;
+
+  if (larger == 0) {
+    return 0;
+  }
+
+  fpt ratio = fpt_div(smaller, larger);
+  fpt normalized = fpt_sqrt(fpt_add(FIXEDPT_ONE, fpt_mul(ratio, ratio)));
+  fpt max_value = (fpt)(((fptu)~0) >> 1);
+  if (larger > fpt_div(max_value, normalized)) {
+    return max_value;
+  }
+  return fpt_mul(larger, normalized);
+}
+
 static inline fpt minsd(fpt a, fpt b) { return (a < b) ? a : b; }
 
 #endif // !_MATH_H_

--- a/driver/params.h
+++ b/driver/params.h
@@ -35,6 +35,34 @@ PARAM(INPUT_DPI, 65536000, // 1000 << 16
 
 PARAM(ANGLE_ROTATION, 0,
       "Apply rotation (degrees) to the mouse movement input");
+char *PARAM_ANGLE_SNAP = "0";
+fpt PARAM_ANGLE_SNAP_THRESHOLD = 0;
+
+static int _set_angle_snap(const char *value, const struct kernel_param *param) {
+  int result = param_set_charp(value, param);
+  if (result != 0) {
+    return result;
+  }
+
+  fpt degrees = atofp(PARAM_ANGLE_SNAP);
+  if (degrees > fpt_fromint(45)) {
+    degrees = fpt_fromint(45);
+  }
+  PARAM_ANGLE_SNAP_THRESHOLD =
+      fpt_tan(fpt_mul(degrees, fpt_div(FIXEDPT_PI, fpt_fromint(180))));
+  return 0;
+}
+
+static const struct kernel_param_ops _angle_snap_ops = {
+    .set = _set_angle_snap,
+    .get = param_get_charp,
+    .free = param_free_charp,
+};
+
+module_param_cb(ANGLE_SNAP, &_angle_snap_ops, &PARAM_ANGLE_SNAP, RW_USER_GROUP);
+MODULE_PARM_DESC(
+    ANGLE_SNAP,
+    "Snap mouse movement to the nearest axis within this angle (degrees)");
 // For Linear Mode
 
 PARAM(ACCEL, 0, "Control the sensitivity calculation.");

--- a/driver/speed.h
+++ b/driver/speed.h
@@ -11,13 +11,11 @@
  */
 static fpt LAST_INPUT_MOUSE_SPEED = 0;
 
-static inline fpt input_speed(fpt dx, fpt dy, fpt time_ms) {
+static inline fpt input_speed_from_distance(fpt distance, fpt time_ms) {
   if (time_ms <= 0) {
     LAST_INPUT_MOUSE_SPEED = 0;
     return 0;
   }
-
-  fpt distance = magnitude((struct vector){dx, dy});
 
   if (distance == -1) {
     dbg("distance calculation failed: t = %s", fptoa(time_ms));
@@ -34,6 +32,15 @@ static inline fpt input_speed(fpt dx, fpt dy, fpt time_ms) {
   dbg("speed (in)                 %s", fptoa(speed));
 
   return speed;
+}
+
+static inline fpt input_speed(fpt dx, fpt dy, fpt time_ms) {
+  if (time_ms <= 0) {
+    LAST_INPUT_MOUSE_SPEED = 0;
+    return 0;
+  }
+
+  return input_speed_from_distance(magnitude((struct vector){dx, dy}), time_ms);
 }
 
 #endif // !__SPEED_H__

--- a/driver/tests/accel.test.c
+++ b/driver/tests/accel.test.c
@@ -189,6 +189,90 @@ no_accel_test(no_accel_yx_ratio, 0.5, 1.5);
 rotation_test(rotation_45_degrees, 1, 45);
 rotation_test(rotation_90_degrees, 1, 90);
 
+TEST angle_snap_horizontal(void) {
+  struct accel_args args = {
+      .sens_mult = FIXEDPT_ONE,
+      .yx_ratio = FIXEDPT_ONE,
+      .input_dpi = fpt_fromint(1000),
+      .angle_snap_threshold = snap_threshold(fpt_fromint(10)),
+      .tag = no_accel,
+  };
+  int x = 10;
+  int y = 1;
+
+  f_accelerate(&x, &y, FIXEDPT_ONE, args);
+
+  ASSERT_EQ(10, x);
+  ASSERT_EQ(0, y);
+  PASS();
+}
+
+TEST angle_snap_vertical(void) {
+  struct vector snapped = snap_to_axis(
+      (struct vector){fpt_fromint(1), fpt_fromint(-10)},
+      snap_threshold(fpt_fromint(10)));
+
+  ASSERT_EQ(0, snapped.x);
+  ASSERT(snapped.y < 0);
+  fpt expected = magnitude((struct vector){fpt_fromint(1), fpt_fromint(-10)});
+  ASSERT(fpt_abs(expected - fpt_abs(snapped.y)) < fpt_rconst(0.0001));
+  PASS();
+}
+
+TEST angle_snap_leaves_movement_outside_threshold(void) {
+  struct vector input = {fpt_fromint(10), fpt_fromint(2)};
+  struct vector snapped = snap_to_axis(input, snap_threshold(fpt_fromint(10)));
+
+  ASSERT_EQ(input.x, snapped.x);
+  ASSERT_EQ(input.y, snapped.y);
+  PASS();
+}
+
+TEST angle_snap_leaves_diagonal_at_forty_five_degrees(void) {
+  struct vector input = {fpt_fromint(10), fpt_fromint(10)};
+  struct vector snapped = snap_to_axis(input, snap_threshold(fpt_fromint(45)));
+
+  ASSERT_EQ(input.x, snapped.x);
+  ASSERT_EQ(input.y, snapped.y);
+  PASS();
+}
+
+TEST angle_snap_is_applied_after_rotation(void) {
+  struct accel_args args = {
+      .sens_mult = FIXEDPT_ONE,
+      .yx_ratio = FIXEDPT_ONE,
+      .input_dpi = fpt_fromint(1000),
+      .angle_rotation_deg = fpt_fromint(-5),
+      .angle_snap_threshold = snap_threshold(fpt_fromint(10)),
+      .tag = no_accel,
+  };
+  int x = 100;
+  int y = 10;
+
+  f_accelerate(&x, &y, FIXEDPT_ONE, args);
+
+  ASSERT(x >= 101);
+  ASSERT_EQ(0, y);
+  PASS();
+}
+
+TEST angle_snap_handles_large_vectors(void) {
+  struct vector snapped = snap_to_axis(
+      (struct vector){fpt_fromint(46341), fpt_fromint(1)},
+      snap_threshold(fpt_fromint(10)));
+
+  ASSERT(snapped.x > 0);
+  ASSERT_EQ(0, snapped.y);
+
+  fpt max_value = (fpt)(((fptu)~0) >> 1);
+  snapped = snap_to_axis(
+      (struct vector){fpt_fromint(2147483647), fpt_fromint(100000000)},
+      snap_threshold(fpt_fromint(10)));
+  ASSERT_EQ(max_value, snapped.x);
+  ASSERT_EQ(0, snapped.y);
+  PASS();
+}
+
 SUITE(acceleration) {
   RUN_TEST(linear_identity);
   RUN_TEST(linear_default);
@@ -205,6 +289,12 @@ SUITE(acceleration) {
   RUN_TEST(no_accel_yx_ratio);
   RUN_TEST(rotation_45_degrees);
   RUN_TEST(rotation_90_degrees);
+  RUN_TEST(angle_snap_horizontal);
+  RUN_TEST(angle_snap_vertical);
+  RUN_TEST(angle_snap_leaves_movement_outside_threshold);
+  RUN_TEST(angle_snap_leaves_diagonal_at_forty_five_degrees);
+  RUN_TEST(angle_snap_is_applied_after_rotation);
+  RUN_TEST(angle_snap_handles_large_vectors);
 }
 
 GREATEST_MAIN_DEFS();

--- a/module.nix
+++ b/module.nix
@@ -35,6 +35,7 @@ with lib; let
     YX_RATIO = cfg.parameters.yxRatio;
     INPUT_DPI = cfg.parameters.inputDpi;
     ANGLE_ROTATION = cfg.parameters.angleRotation;
+    ANGLE_SNAP = cfg.parameters.angleSnap;
     MODE = cfg.parameters.mode;
 
     # Linear mode parameters
@@ -160,6 +161,14 @@ in {
         type = types.nullOr types.float;
         default = null;
         description = "Apply rotation in degrees to mouse movement input.";
+      };
+
+      angleSnap = mkOption {
+        type =
+          types.nullOr (types.addCheck types.float (x: x >= 0.0 && x <= 45.0)
+            // {description = "float between 0.0 and 45.0";});
+        default = null;
+        description = "Snap movement to the nearest axis within this angle in degrees.";
       };
 
       mode = mkOption {


### PR DESCRIPTION
## Summary
- add configurable 0-45 degree axis snapping after input rotation
- expose `ANGLE_SNAP` through the driver, CLI, TUI, persistence, and NixOS module
- preserve movement magnitude and avoid overflow for large vectors
- keep existing bulk-set CLI syntax compatible
- bump CLI and driver package versions

## Verification
- `cargo fmt --all --check`
- `cargo test --all`
- `make test`
- `make build`

Fixes #107