### PR TITLE
Cache driver acceleration configuration

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=maccel-dkms
 _pkgname="maccel"
-pkgver=0.5.9
+pkgver=0.5.10
 pkgrel=1
 pkgdesc="Mouse acceleration driver and kernel module for Linux."
 arch=("x86_64")

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -28,4 +28,4 @@ test_debug: test
 
 test: **/*.test.c
 	@mkdir -p tests/snapshots
-	DRIVER_CFLAGS="$(DRIVER_CFLAGS)" TEST_NAME=$(name) sh tests/run_tests.sh
+	DRIVER_CFLAGS="$(DRIVER_CFLAGS)" TEST_NAME=$(name) bash tests/run_tests.sh

--- a/driver/accel.h
+++ b/driver/accel.h
@@ -29,7 +29,62 @@ struct accel_args {
   union __accel_args args;
 };
 
+union __prepared_accel_args {
+  struct prepared_natural_curve_args natural;
+  struct prepared_linear_curve_args linear;
+  struct prepared_synchronous_curve_args synchronous;
+  struct no_accel_curve_args no_accel;
+};
+
+struct prepared_accel_args {
+  fpt sens_mult;
+  fpt yx_ratio;
+  fpt dpi_factor;
+  fpt cos_angle;
+  fpt sin_angle;
+  bool rotation_enabled;
+  enum accel_mode tag;
+  union __prepared_accel_args args;
+};
+
 const fpt NORMALIZED_DPI = fpt_fromint(1000);
+const fpt DEG_TO_RAD_FACTOR = fpt_xdiv(FIXEDPT_PI, fpt_rconst(180));
+
+static inline struct prepared_accel_args
+prepare_accel_args(struct accel_args args) {
+  struct prepared_accel_args prepared = {
+      .sens_mult = args.sens_mult,
+      .yx_ratio = args.yx_ratio,
+      .dpi_factor = fpt_div(NORMALIZED_DPI, args.input_dpi),
+      .cos_angle = FIXEDPT_ONE,
+      .rotation_enabled = args.angle_rotation_deg != 0,
+      .tag = args.tag,
+  };
+
+  if (prepared.rotation_enabled) {
+    fpt radians = fpt_mul(args.angle_rotation_deg, DEG_TO_RAD_FACTOR);
+    prepared.cos_angle = fpt_cos(radians);
+    prepared.sin_angle = fpt_sin(radians);
+  }
+
+  switch (args.tag) {
+  case synchronous:
+    prepared.args.synchronous =
+        prepare_synchronous_curve_args(args.args.synchronous);
+    break;
+  case natural:
+    prepared.args.natural = prepare_natural_curve_args(args.args.natural);
+    break;
+  case linear:
+    prepared.args.linear = prepare_linear_curve_args(args.args.linear);
+    break;
+  case no_accel:
+  default:
+    break;
+  }
+
+  return prepared;
+}
 
 /**
  * Calculate the factor by which to multiply the input vector
@@ -60,14 +115,41 @@ static inline struct vector sensitivity(fpt input_speed,
   default:
     sens = FIXEDPT_ONE;
   }
+
   sens = fpt_mul(sens, args.sens_mult);
   return (struct vector){sens, fpt_mul(sens, args.yx_ratio)};
 }
 
-const fpt DEG_TO_RAD_FACTOR = fpt_xdiv(FIXEDPT_PI, fpt_rconst(180));
+static inline struct vector
+prepared_sensitivity(fpt input_speed, struct prepared_accel_args args) {
+  fpt sens;
 
-static inline void f_accelerate(int *x, int *y, fpt time_interval_ms,
-                                struct accel_args args) {
+  switch (args.tag) {
+  case synchronous:
+    dbg("accel mode %d: synchronous", args.tag);
+    sens = __prepared_synchronous_sens_fun(input_speed, args.args.synchronous);
+    break;
+  case natural:
+    dbg("accel mode %d: natural", args.tag);
+    sens = __prepared_natural_sens_fun(input_speed, args.args.natural);
+    break;
+  case linear:
+    dbg("accel mode %d: linear", args.tag);
+    sens = __prepared_linear_sens_fun(input_speed, args.args.linear);
+    break;
+  case no_accel:
+    dbg("accel mode %d: no_accel", args.tag);
+    sens = FIXEDPT_ONE;
+    break;
+  default:
+    sens = FIXEDPT_ONE;
+  }
+  sens = fpt_mul(sens, args.sens_mult);
+  return (struct vector){sens, fpt_mul(sens, args.yx_ratio)};
+}
+
+static inline void f_accelerate_prepared(int *x, int *y, fpt time_interval_ms,
+                                         struct prepared_accel_args args) {
   static fpt carry_x = 0;
   static fpt carry_y = 0;
 
@@ -75,25 +157,13 @@ static inline void f_accelerate(int *x, int *y, fpt time_interval_ms,
   fpt dy = fpt_fromint(*y);
 
   {
-    if (args.angle_rotation_deg == 0) {
+    if (!args.rotation_enabled) {
       goto accel_routine;
     }
-    // Add rotation of input vector
-    fpt degrees = args.angle_rotation_deg;
-    fpt radians =
-        fpt_mul(degrees, DEG_TO_RAD_FACTOR); // Convert degrees to radians
-
-    fpt cos_angle = fpt_cos(radians);
-    fpt sin_angle = fpt_sin(radians);
-
-    dbg("rotation angle(deg):     %s deg", fptoa(degrees));
-    dbg("rotation angle(rad):     %s rad", fptoa(radians));
-    dbg("cosine of rotation:      %s", fptoa(cos_angle));
-    dbg("sine of rotation:        %s", fptoa(sin_angle));
 
     // Rotate input vector
-    fpt dx_rot = fpt_mul(dx, cos_angle) - fpt_mul(dy, sin_angle);
-    fpt dy_rot = fpt_mul(dx, sin_angle) + fpt_mul(dy, cos_angle);
+    fpt dx_rot = fpt_mul(dx, args.cos_angle) - fpt_mul(dy, args.sin_angle);
+    fpt dy_rot = fpt_mul(dx, args.sin_angle) + fpt_mul(dy, args.cos_angle);
 
     dbg("rotated x:               %s", fptoa(dx_rot));
     dbg("rotated y:               %s", fptoa(dy_rot));
@@ -107,13 +177,12 @@ accel_routine:
   dbg("in: x (fpt conversion) %s", fptoa(dx));
   dbg("in: y (fpt conversion) %s", fptoa(dy));
 
-  fpt dpi_factor = fpt_div(NORMALIZED_DPI, args.input_dpi);
-  dbg("dpi adjustment factor:     %s", fptoa(dpi_factor));
-  dx = fpt_mul(dx, dpi_factor);
-  dy = fpt_mul(dy, dpi_factor);
+  dbg("dpi adjustment factor:     %s", fptoa(args.dpi_factor));
+  dx = fpt_mul(dx, args.dpi_factor);
+  dy = fpt_mul(dy, args.dpi_factor);
 
   fpt speed_in = input_speed(dx, dy, time_interval_ms);
-  struct vector sens = sensitivity(speed_in, args);
+  struct vector sens = prepared_sensitivity(speed_in, args);
   dbg("scale x                    %s", fptoa(sens.x));
   dbg("scale y                    %s", fptoa(sens.y));
 
@@ -135,6 +204,11 @@ accel_routine:
   carry_y = fpt_sub(dy_out, fpt_fromint(*y));
 
   dbg("carry                     (%s, %s)", fptoa(carry_x), fptoa(carry_x));
+}
+
+static inline void f_accelerate(int *x, int *y, fpt time_interval_ms,
+                                struct accel_args args) {
+  f_accelerate_prepared(x, y, time_interval_ms, prepare_accel_args(args));
 }
 
 #endif

--- a/driver/accel/linear.h
+++ b/driver/accel/linear.h
@@ -11,6 +11,34 @@ struct linear_curve_args {
   fpt output_cap;
 };
 
+struct prepared_linear_curve_args {
+  fpt accel;
+  fpt offset;
+  fpt cap;
+  fpt sign;
+  bool has_cap;
+};
+
+static inline struct prepared_linear_curve_args
+prepare_linear_curve_args(struct linear_curve_args args) {
+  struct prepared_linear_curve_args prepared = {
+      .accel = args.accel,
+      .offset = args.offset,
+      .sign = FIXEDPT_ONE,
+      .has_cap = args.output_cap > 0,
+  };
+
+  if (prepared.has_cap) {
+    prepared.cap = fpt_sub(args.output_cap, FIXEDPT_ONE);
+    if (prepared.cap < 0) {
+      prepared.cap = -prepared.cap;
+      prepared.sign = -prepared.sign;
+    }
+  }
+
+  return prepared;
+}
+
 static inline fpt linear_base_fn(fpt x, fpt accel,
                                      fpt input_offset) {
   fpt _x = x - input_offset;
@@ -22,11 +50,11 @@ static inline fpt linear_base_fn(fpt x, fpt accel,
 /**
  * Sensitivity Function for Linear Acceleration
  */
-static inline fpt __linear_sens_fun(fpt input_speed,
-                                        struct linear_curve_args args) {
+static inline fpt
+__prepared_linear_sens_fun(fpt input_speed,
+                           struct prepared_linear_curve_args args) {
   dbg("linear: accel             %s", fptoa(args.accel));
   dbg("linear: offset            %s", fptoa(args.offset));
-  dbg("linear: output_cap        %s", fptoa(args.output_cap));
 
   if (input_speed <= args.offset) {
     return FIXEDPT_ONE;
@@ -35,16 +63,15 @@ static inline fpt __linear_sens_fun(fpt input_speed,
   fpt sens = linear_base_fn(input_speed, args.accel, args.offset);
   dbg("linear: base_fn sens       %s", fptoa(args.accel));
 
-  fpt sign = FIXEDPT_ONE;
-  if (args.output_cap > 0) {
-    fpt cap = fpt_sub(args.output_cap, FIXEDPT_ONE);
-    if (cap < 0) {
-      cap = -cap;
-      sign = -sign;
-    }
-    sens = minsd(sens, cap);
-  }
+  if (args.has_cap)
+    sens = minsd(sens, args.cap);
 
-  return fpt_add(FIXEDPT_ONE, fpt_mul(sign, sens));
+  return fpt_add(FIXEDPT_ONE, fpt_mul(args.sign, sens));
+}
+
+static inline fpt __linear_sens_fun(fpt input_speed,
+                                    struct linear_curve_args args) {
+  return __prepared_linear_sens_fun(input_speed,
+                                    prepare_linear_curve_args(args));
 }
 #endif // !__ACCEL_LINEAR_H_

--- a/driver/accel/natural.h
+++ b/driver/accel/natural.h
@@ -9,40 +9,62 @@ struct natural_curve_args {
   fpt limit;
 };
 
+struct prepared_natural_curve_args {
+  fpt offset;
+  fpt limit;
+  fpt accel;
+  fpt constant;
+  bool enabled;
+};
+
+static inline struct prepared_natural_curve_args
+prepare_natural_curve_args(struct natural_curve_args args) {
+  struct prepared_natural_curve_args prepared = {
+      .offset = args.offset,
+      .enabled = args.limit > FIXEDPT_ONE && args.decay_rate > 0,
+  };
+
+  if (prepared.enabled) {
+    prepared.limit = args.limit - FIXEDPT_ONE;
+    prepared.accel = fpt_div(args.decay_rate, fpt_abs(prepared.limit));
+    prepared.constant = fpt_div(-prepared.limit, prepared.accel);
+  }
+
+  return prepared;
+}
+
 /**
  * Gain Function for Natural Acceleration
  */
-static inline fpt __natural_sens_fun(fpt input_speed,
-                                         struct natural_curve_args args) {
-  dbg("natural: decay_rate        %s", fptoa(args.decay_rate));
+static inline fpt
+__prepared_natural_sens_fun(fpt input_speed,
+                            struct prepared_natural_curve_args args) {
   dbg("natural: offset            %s", fptoa(args.offset));
   dbg("natural: limit             %s", fptoa(args.limit));
   if (input_speed <= args.offset) {
     return FIXEDPT_ONE;
   }
 
-  if (args.limit <= FIXEDPT_ONE) {
+  if (!args.enabled) {
     return FIXEDPT_ONE;
   }
 
-  if (args.decay_rate <= 0) {
-    return FIXEDPT_ONE;
-  }
-
-  fpt limit = args.limit - FIXEDPT_ONE;
-  fpt accel = fpt_div(args.decay_rate, fpt_abs(limit));
-  fpt constant = fpt_div(-limit, accel);
-
-  dbg("natural: constant          %s", fptoa(constant));
+  dbg("natural: constant          %s", fptoa(args.constant));
 
   fpt offset_x = args.offset - input_speed;
-  fpt decay = fpt_exp(fpt_mul(accel, offset_x));
+  fpt decay = fpt_exp(fpt_mul(args.accel, offset_x));
 
   dbg("natural: decay             %s", fptoa(decay));
 
-  fpt output_denom = fpt_div(decay, accel) - offset_x;
-  fpt output = fpt_mul(limit, output_denom) + constant;
+  fpt output_denom = fpt_div(decay, args.accel) - offset_x;
+  fpt output = fpt_mul(args.limit, output_denom) + args.constant;
 
   return fpt_div(output, input_speed) + FIXEDPT_ONE;
+}
+
+static inline fpt __natural_sens_fun(fpt input_speed,
+                                     struct natural_curve_args args) {
+  return __prepared_natural_sens_fun(input_speed,
+                                     prepare_natural_curve_args(args));
 }
 #endif

--- a/driver/accel/synchronous.h
+++ b/driver/accel/synchronous.h
@@ -10,55 +10,83 @@ struct synchronous_curve_args {
   fpt sync_speed;
 };
 
+struct prepared_synchronous_curve_args {
+  fpt gamma_const;
+  fpt log_motivity;
+  fpt log_syncspeed;
+  fpt sync_speed;
+  fpt sharpness;
+  fpt sharpness_recip;
+  fpt minimum_sens;
+  fpt maximum_sens;
+  bool use_linear_clamp;
+};
+
+static inline struct prepared_synchronous_curve_args
+prepare_synchronous_curve_args(struct synchronous_curve_args args) {
+  fpt log_motivity = fpt_ln(args.motivity);
+  fpt sharpness = args.smooth == 0 ? fpt_rconst(16.0)
+                                   : fpt_div(fpt_rconst(0.5), args.smooth);
+
+  return (struct prepared_synchronous_curve_args){
+      .gamma_const = fpt_div(args.gamma, log_motivity),
+      .log_motivity = log_motivity,
+      .log_syncspeed = fpt_ln(args.sync_speed),
+      .sync_speed = args.sync_speed,
+      .sharpness = sharpness,
+      .sharpness_recip = fpt_div(FIXEDPT_ONE, sharpness),
+      .minimum_sens = fpt_div(FIXEDPT_ONE, args.motivity),
+      .maximum_sens = args.motivity,
+      .use_linear_clamp = sharpness >= fpt_rconst(16.0),
+  };
+}
+
 /**
  * Sensitivity Function for `Synchronous` Acceleration
  */
-static inline fpt __synchronous_sens_fun(fpt input_speed,
-                                         struct synchronous_curve_args args) {
-  fpt log_motivity = fpt_ln(args.motivity);
-  fpt gamma_const = fpt_div(args.gamma, log_motivity);
-  fpt log_syncspeed = fpt_ln(args.sync_speed);
-  fpt syncspeed = args.sync_speed;
-  fpt sharpness = args.smooth == 0 ? fpt_rconst(16.0)
-                                   : fpt_div(fpt_rconst(0.5), args.smooth);
-  int use_linear_clamp = sharpness >= fpt_rconst(16.0);
-  fpt sharpness_recip = fpt_div(FIXEDPT_ONE, sharpness);
-  fpt minimum_sens = fpt_div(FIXEDPT_ONE, args.motivity);
-  fpt maximum_sens = args.motivity;
-
+static inline fpt
+__prepared_synchronous_sens_fun(fpt input_speed,
+                                struct prepared_synchronous_curve_args args) {
   // if sharpness >= 16, use linear clamp for activation function.
   // linear clamp means: fpt_clamp(input_speed, -1, 1).
-  if (use_linear_clamp) {
-    fpt log_space = fpt_mul(gamma_const, (fpt_ln(input_speed) - log_syncspeed));
+  if (args.use_linear_clamp) {
+    fpt log_space =
+        fpt_mul(args.gamma_const, (fpt_ln(input_speed) - args.log_syncspeed));
 
     if (log_space < -FIXEDPT_ONE) {
-      return minimum_sens;
+      return args.minimum_sens;
     }
 
     if (log_space > FIXEDPT_ONE) {
-      return maximum_sens;
+      return args.maximum_sens;
     }
 
-    return fpt_exp(fpt_mul(log_space, log_motivity));
+    return fpt_exp(fpt_mul(log_space, args.log_motivity));
   }
 
-  if (input_speed == syncspeed) {
+  if (input_speed == args.sync_speed) {
     return FIXEDPT_ONE;
   }
 
   fpt log_x = fpt_ln(input_speed);
-  fpt log_diff = log_x - log_syncspeed;
+  fpt log_diff = log_x - args.log_syncspeed;
 
   if (log_diff > 0) {
-    fpt log_space = fpt_mul(gamma_const, log_diff);
-    fpt exponent =
-        fpt_pow(fpt_tanh(fpt_pow(log_space, sharpness)), sharpness_recip);
-    return fpt_exp(fpt_mul(exponent, log_motivity));
+    fpt log_space = fpt_mul(args.gamma_const, log_diff);
+    fpt exponent = fpt_pow(fpt_tanh(fpt_pow(log_space, args.sharpness)),
+                           args.sharpness_recip);
+    return fpt_exp(fpt_mul(exponent, args.log_motivity));
   } else {
-    fpt log_space = fpt_mul(-gamma_const, log_diff);
-    fpt exponent =
-        -fpt_pow(fpt_tanh(fpt_pow(log_space, sharpness)), sharpness_recip);
-    return fpt_exp(fpt_mul(exponent, log_motivity));
+    fpt log_space = fpt_mul(-args.gamma_const, log_diff);
+    fpt exponent = -fpt_pow(fpt_tanh(fpt_pow(log_space, args.sharpness)),
+                            args.sharpness_recip);
+    return fpt_exp(fpt_mul(exponent, args.log_motivity));
   }
+}
+
+static inline fpt __synchronous_sens_fun(fpt input_speed,
+                                         struct synchronous_curve_args args) {
+  return __prepared_synchronous_sens_fun(input_speed,
+                                         prepare_synchronous_curve_args(args));
 }
 #endif

--- a/driver/accel_k.h
+++ b/driver/accel_k.h
@@ -6,10 +6,11 @@
 #include "accel/mode.h"
 #include "fixedptc.h"
 #include "linux/ktime.h"
+#include "linux/seqlock.h"
 #include "params.h"
 #include "speed.h"
 
-static struct accel_args collect_args(void) {
+static struct accel_args parse_accel_args(void) {
   struct accel_args accel = {0};
 
   enum accel_mode mode = PARAM_MODE;
@@ -47,6 +48,30 @@ static struct accel_args collect_args(void) {
   return accel;
 }
 
+static DEFINE_SEQLOCK(accel_args_lock);
+static struct prepared_accel_args cached_args;
+
+static void refresh_cached_args(void) {
+  struct prepared_accel_args next = prepare_accel_args(parse_accel_args());
+  unsigned long flags;
+
+  write_seqlock_irqsave(&accel_args_lock, flags);
+  cached_args = next;
+  write_sequnlock_irqrestore(&accel_args_lock, flags);
+}
+
+static struct prepared_accel_args collect_args(void) {
+  struct prepared_accel_args args;
+  unsigned sequence;
+
+  do {
+    sequence = read_seqbegin(&accel_args_lock);
+    args = cached_args;
+  } while (read_seqretry(&accel_args_lock, sequence));
+
+  return args;
+}
+
 #if FIXEDPT_BITS == 64
 const fpt UNIT_PER_MS = fpt_rconst(1000000); // 1 million nanoseconds
 #else
@@ -81,7 +106,7 @@ static inline void accelerate(int *x, int *y) {
       fptoa(millisecond));
 #endif
 
-  return f_accelerate(x, y, millisecond, collect_args());
+  f_accelerate_prepared(x, y, millisecond, collect_args());
 }
 
 #endif // !_ACCELK_H_

--- a/driver/fixedptc.h
+++ b/driver/fixedptc.h
@@ -79,6 +79,7 @@
 #include <linux/stddef.h>
 #include <linux/types.h>
 #else
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #endif

--- a/driver/input_handler.h
+++ b/driver/input_handler.h
@@ -67,6 +67,46 @@ static void event(struct input_handle *handle, struct input_value *value_ptr) {
 }
 
 #if __cleanup_events
+static noinline __cold unsigned int
+inject_rotation_events(struct input_handle *handle, struct input_value *vals,
+                       struct input_value *end) {
+  struct input_value *v;
+  struct input_value *syn_pos = NULL;
+  unsigned int count = end - vals;
+  unsigned int max = handle->dev->max_vals;
+
+  for (v = vals; v != end; v++) {
+    if (v->type == EV_SYN && v->code == SYN_REPORT)
+      syn_pos = v;
+  }
+
+  if (injected_x && synthetic_x_val != NONE_EVENT_VALUE && count < max) {
+    if (syn_pos) {
+      memmove(syn_pos + 1, syn_pos, (end - syn_pos) * sizeof(*syn_pos));
+      syn_pos->type = EV_REL;
+      syn_pos->code = REL_X;
+      syn_pos->value = synthetic_x_val;
+      syn_pos++;
+      end++;
+      count++;
+    }
+    dbg("rotation: injected synthetic REL_X = %d", synthetic_x_val);
+  }
+
+  if (injected_y && synthetic_y_val != NONE_EVENT_VALUE && count < max) {
+    if (syn_pos) {
+      memmove(syn_pos + 1, syn_pos, (end - syn_pos) * sizeof(*syn_pos));
+      syn_pos->type = EV_REL;
+      syn_pos->code = REL_Y;
+      syn_pos->value = synthetic_y_val;
+      count++;
+    }
+    dbg("rotation: injected synthetic REL_Y = %d", synthetic_y_val);
+  }
+
+  return count;
+}
+
 static unsigned int maccel_events(struct input_handle *handle,
                                   struct input_value *vals,
                                   unsigned int count) {
@@ -103,42 +143,8 @@ static void maccel_events(struct input_handle *handle,
    * Writing extra events into the buffer on those kernels is undefined
    * behavior — the kernel won't deliver them and may behave erratically.
    */
-  {
-    struct input_value *syn_pos = NULL;
-    unsigned int max = handle->dev->max_vals;
-
-    /* Find the last SYN_REPORT so we can insert before it */
-    for (v = vals; v != end; v++) {
-      if (v->type == EV_SYN && v->code == SYN_REPORT)
-        syn_pos = v;
-    }
-
-    if (injected_x && synthetic_x_val != NONE_EVENT_VALUE && _count < max) {
-      if (syn_pos) {
-        /* Shift SYN_REPORT and everything after it forward by one */
-        memmove(syn_pos + 1, syn_pos, (end - syn_pos) * sizeof(*syn_pos));
-        syn_pos->type = EV_REL;
-        syn_pos->code = REL_X;
-        syn_pos->value = synthetic_x_val;
-        syn_pos++;
-        end++;
-        _count++;
-      }
-      dbg("rotation: injected synthetic REL_X = %d", synthetic_x_val);
-    }
-
-    if (injected_y && synthetic_y_val != NONE_EVENT_VALUE && _count < max) {
-      if (syn_pos) {
-        memmove(syn_pos + 1, syn_pos, (end - syn_pos) * sizeof(*syn_pos));
-        syn_pos->type = EV_REL;
-        syn_pos->code = REL_Y;
-        syn_pos->value = synthetic_y_val;
-        end++;
-        _count++;
-      }
-      dbg("rotation: injected synthetic REL_Y = %d", synthetic_y_val);
-    }
-  }
+  if (injected_x || injected_y)
+    _count = inject_rotation_events(handle, vals, end);
 #endif
 
   handle->dev->num_vals = _count;

--- a/driver/maccel.c
+++ b/driver/maccel.c
@@ -7,6 +7,7 @@
  */
 static int __init driver_initialization(void) {
   int error;
+  refresh_cached_args();
   error = create_char_device();
   if (error)
     return error;

--- a/driver/params.h
+++ b/driver/params.h
@@ -7,9 +7,40 @@
 
 #define RW_USER_GROUP 0664
 
+static void refresh_cached_args(void);
+
+static int set_param_and_refresh(const char *value,
+                                 const struct kernel_param *param) {
+  int error = param_set_charp(value, param);
+
+  if (!error)
+    refresh_cached_args();
+  return error;
+}
+
+static const struct kernel_param_ops cached_param_ops = {
+    .set = set_param_and_refresh,
+    .get = param_get_charp,
+    .free = param_free_charp,
+};
+
+static int set_flag_and_refresh(const char *value,
+                                const struct kernel_param *param) {
+  int error = param_set_byte(value, param);
+
+  if (!error)
+    refresh_cached_args();
+  return error;
+}
+
+static const struct kernel_param_ops cached_flag_ops = {
+    .set = set_flag_and_refresh,
+    .get = param_get_byte,
+};
+
 #define PARAM(param, default_value, desc)                                      \
   char *PARAM_##param = #default_value;                                        \
-  module_param_named(param, PARAM_##param, charp, RW_USER_GROUP);              \
+  module_param_cb(param, &cached_param_ops, &PARAM_##param, RW_USER_GROUP);    \
   MODULE_PARM_DESC(param, desc);
 
 #if FIXEDPT_BITS == 64
@@ -82,7 +113,7 @@ PARAM(SYNC_SPEED, 327680, // 5 << 16
 // Flags
 #define PARAM_FLAG(param, default_value, desc)                                 \
   unsigned char PARAM_##param = default_value;                                 \
-  module_param_named(param, PARAM_##param, byte, RW_USER_GROUP);               \
+  module_param_cb(param, &cached_flag_ops, &PARAM_##param, RW_USER_GROUP);     \
   MODULE_PARM_DESC(param, desc);
 
 PARAM_FLAG(MODE, linear, "Desired type of acceleration.");

--- a/driver/tests/accel.test.c
+++ b/driver/tests/accel.test.c
@@ -6,6 +6,7 @@ static int test_acceleration(const char *filename, struct accel_args args) {
   const int LINE_LEN = 26;
   const int MIN = -128;
   const int MAX = 127;
+  struct prepared_accel_args prepared = prepare_accel_args(args);
 
   char content[256 * 256 * LINE_LEN + 1];
   strcpy(content, ""); // initialize as an empty string
@@ -16,7 +17,7 @@ static int test_acceleration(const char *filename, struct accel_args args) {
       int x_out = x;
       int y_out = y;
 
-      f_accelerate(&x_out, &y_out, FIXEDPT_ONE, args);
+      f_accelerate_prepared(&x_out, &y_out, FIXEDPT_ONE, prepared);
 
       char curr_debug_print[LINE_LEN];
 


### PR DESCRIPTION
## Summary
- parse module parameters and derive DPI, rotation, and curve constants only when configuration changes
- publish prepared configuration to the input path with a seqlock
- move synthetic rotation event insertion to a cold, out-of-line helper
- bump the driver package version to 0.5.10

## Performance
- standalone fixed-point benchmark: 1.2x-1.46x faster prepared acceleration path before counting eliminated string parsing
- rebuilt `maccel_events`: 10,744 bytes down to 611 bytes, with the 7,579-byte acceleration routine outlined

## Verification
- `make build`
- `make test`
- `cargo test --all`
- Kimi K3 adversarial diff review: no findings

Runtime hardware verification was intentionally omitted because it requires loading the kernel module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved acceleration processing with more consistent sensitivity, scaling, rotation, and curve behavior.
  * Configuration changes are applied more reliably after parameter updates and during driver startup.
  * Improved handling of synthetic rotation input events on newer Linux kernels.

* **Bug Fixes**
  * Preserved acceleration boundary and cap behavior while improving runtime consistency.

* **Chores**
  * Updated the package version from 0.5.9 to 0.5.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->